### PR TITLE
Implemented dispatching of cancel requests

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -1,57 +1,22 @@
 package rpc
 
 import (
-	"golang.org/x/net/context"
 	"io"
-	"sync"
+
+	"golang.org/x/net/context"
 )
-
-type ServeHandlerDescription struct {
-	MakeArg    func() interface{}
-	Handler    func(ctx context.Context, arg interface{}) (ret interface{}, err error)
-	MethodType MethodType
-}
-
-type MethodType int
-
-const (
-	MethodCall     MethodType = 0
-	MethodResponse            = 1
-	MethodNotify              = 2
-	MethodCancel              = 3
-)
-
-type ErrorUnwrapper interface {
-	MakeArg() interface{}
-	UnwrapError(arg interface{}) (appError error, dispatchError error)
-}
 
 type dispatcher interface {
 	Call(ctx context.Context, name string, arg interface{}, res interface{}, u ErrorUnwrapper) error
 	Notify(ctx context.Context, name string, arg interface{}) error
-	RegisterProtocol(Protocol) error
-	Dispatch(l int) error
 	Close(err error) chan struct{}
-	AddCloseListener(chan error)
-}
-
-type Protocol struct {
-	Name      string
-	Methods   map[string]ServeHandlerDescription
-	WrapError WrapErrorFunc
 }
 
 type dispatch struct {
-	transmitter encoder
-	receiver    byteReadingDecoder
+	writer encoder
+	reader byteReadingDecoder
 
-	protocols     map[string]Protocol
-	seqid         int
-	wrapErrorFunc WrapErrorFunc
-	tasks         map[int]context.CancelFunc
-
-	listeners   map[chan error]struct{}
-	listenerMtx sync.Mutex
+	seqid int
 
 	// Stops all loops when closed
 	stopCh chan struct{}
@@ -60,51 +25,34 @@ type dispatch struct {
 
 	callCh     chan *call
 	callRespCh chan *call
-	rmCallCh   chan int
+	rmCallCh   chan callRetrieval
 
 	// Task loop channels
 	taskBeginCh  chan *task
 	taskCancelCh chan int
 	taskEndCh    chan int
 
-	log              LogInterface
-	dispatchHandlers map[MethodType]messageHandler
+	log LogInterface
 }
 
-type messageHandler struct {
-	dispatchFunc  func() error
-	messageLength int
-}
-
-func newDispatch(enc encoder, dec byteReadingDecoder, l LogInterface, wef WrapErrorFunc) *dispatch {
+func newDispatch(enc encoder, dec byteReadingDecoder, callRetrievalCh chan callRetrieval, l LogInterface) *dispatch {
 	d := &dispatch{
-		transmitter: enc,
-		receiver:    dec,
-		protocols:   make(map[string]Protocol),
-		listeners:   make(map[chan error]struct{}),
-		tasks:       make(map[int]context.CancelFunc),
-		callCh:      make(chan *call),
-		callRespCh:  make(chan *call),
-		rmCallCh:    make(chan int),
-		stopCh:      make(chan struct{}),
-		closedCh:    make(chan struct{}),
+		writer:     enc,
+		reader:     dec,
+		callCh:     make(chan *call),
+		callRespCh: make(chan *call),
+		rmCallCh:   callRetrievalCh,
+		stopCh:     make(chan struct{}),
+		closedCh:   make(chan struct{}),
 
 		taskBeginCh:  make(chan *task),
 		taskCancelCh: make(chan int),
 		taskEndCh:    make(chan int),
 
-		seqid:         0,
-		log:           l,
-		wrapErrorFunc: wef,
-	}
-	d.dispatchHandlers = map[MethodType]messageHandler{
-		MethodNotify:   {dispatchFunc: d.dispatchNotify, messageLength: 3},
-		MethodCall:     {dispatchFunc: d.dispatchCall, messageLength: 4},
-		MethodResponse: {dispatchFunc: d.dispatchResponse, messageLength: 4},
-		MethodCancel:   {dispatchFunc: d.dispatchCancel, messageLength: 3},
+		seqid: 0,
+		log:   l,
 	}
 	go d.callLoop()
-	go d.taskLoop()
 	return d
 }
 
@@ -153,59 +101,39 @@ func (d *dispatch) callLoop() {
 			close(d.closedCh)
 			return
 		case c := <-d.callCh:
-			seqid := d.nextSeqid()
-			c.seqid = seqid
-			v := []interface{}{MethodCall, seqid, c.method, c.arg}
-			calls[c.seqid] = c
-			err := d.transmitter.Encode(v)
-			if err != nil {
-				c.Finish(err)
-				continue
-			}
-			d.log.ClientCall(seqid, c.method, c.arg)
-			go func() {
-				select {
-				case <-c.ctx.Done():
-					d.rmCallCh <- seqid
-					<-d.callRespCh
-					c.Finish(newCanceledError(c.method, c.seqid))
-					d.log.ClientCancel(seqid, c.method)
-					v := []interface{}{MethodCancel, seqid, c.method}
-					d.transmitter.Encode(v)
-				case <-c.doneCh:
-				}
-			}()
-		case seqid := <-d.rmCallCh:
-			call := calls[seqid]
-			delete(calls, seqid)
-			d.callRespCh <- call
+			d.handleCall(calls, c)
+		case cr := <-d.rmCallCh:
+			call := calls[cr.seqid]
+			delete(calls, cr.seqid)
+			cr.ch <- call
 		}
 	}
 }
 
-type task struct {
-	seqid      int
-	cancelFunc context.CancelFunc
-}
-
-func (d *dispatch) taskLoop() {
-	tasks := make(map[int]context.CancelFunc)
-	for {
+func (d *dispatch) handleCall(calls map[int]*call, c *call) {
+	seqid := d.nextSeqid()
+	c.seqid = seqid
+	v := []interface{}{MethodCall, seqid, c.method, c.arg}
+	calls[c.seqid] = c
+	err := d.writer.Encode(v)
+	if err != nil {
+		c.Finish(err)
+		return
+	}
+	d.log.ClientCall(seqid, c.method, c.arg)
+	go func() {
 		select {
-		case <-d.stopCh:
-			// TODO cleanup here?
-			return
-		case t := <-d.taskBeginCh:
-			tasks[t.seqid] = t.cancelFunc
-		case seqid := <-d.taskCancelCh:
-			if cancelFunc, ok := tasks[seqid]; ok {
-				cancelFunc()
-			}
-			delete(tasks, seqid)
-		case seqid := <-d.taskEndCh:
-			delete(tasks, seqid)
+		case <-c.ctx.Done():
+			ch := make(chan *call)
+			d.rmCallCh <- callRetrieval{seqid, ch}
+			<-ch
+			c.Finish(newCanceledError(c.method, c.seqid))
+			d.log.ClientCancel(seqid, c.method)
+			v := []interface{}{MethodCancel, seqid, c.method}
+			d.writer.Encode(v)
+		case <-c.doneCh:
 		}
-	}
+	}()
 }
 
 func (d *dispatch) nextSeqid() int {
@@ -223,7 +151,7 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 
 func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}) (err error) {
 	v := []interface{}{MethodNotify, name, arg}
-	err = d.transmitter.Encode(v)
+	err = d.writer.Encode(v)
 	if err != nil {
 		return
 	}
@@ -231,150 +159,9 @@ func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}) (er
 	return
 }
 
-func (d *dispatch) findServeHandler(n string) (*ServeHandlerDescription, WrapErrorFunc, error) {
-	p, m := SplitMethodName(n)
-	prot, found := d.protocols[p]
-	if !found {
-		return nil, d.wrapErrorFunc, ProtocolNotFoundError{p}
-	}
-	srv, found := prot.Methods[m]
-	if !found {
-		return nil, d.wrapErrorFunc, MethodNotFoundError{p, m}
-	}
-	return &srv, prot.WrapError, nil
-}
-
-func (d *dispatch) RegisterProtocol(p Protocol) (err error) {
-	if _, found := d.protocols[p.Name]; found {
-		err = AlreadyRegisteredError{p.Name}
-	} else {
-		d.protocols[p.Name] = p
-	}
-	return err
-}
-
 func (d *dispatch) Close(err error) chan struct{} {
 	close(d.stopCh)
-	d.broadcast(err)
 	return d.closedCh
-}
-
-func (d *dispatch) AddCloseListener(ch chan error) {
-	d.listenerMtx.Lock()
-	defer d.listenerMtx.Unlock()
-	d.listeners[ch] = struct{}{}
-}
-
-func (d *dispatch) broadcast(err error) {
-	d.listenerMtx.Lock()
-	defer d.listenerMtx.Unlock()
-	for ch := range d.listeners {
-		select {
-		case ch <- err:
-		default:
-		}
-	}
-}
-
-func (d *dispatch) Dispatch(length int) error {
-	var requestType MethodType
-	if err := d.receiver.Decode(&requestType); err != nil {
-		return err
-	}
-	handler, ok := d.dispatchHandlers[requestType]
-	if !ok {
-		return NewDispatcherError("invalid message type")
-	}
-	if length != handler.messageLength {
-		return NewDispatcherError("wrong number of fields for message (got n=%d, expected n=%d)", length, handler.messageLength)
-
-	}
-	return handler.dispatchFunc()
-}
-
-func (d *dispatch) dispatchNotify() (err error) {
-	req := newRequest(MethodNotify)
-	return d.handleDispatch(req)
-}
-
-func (d *dispatch) dispatchCall() error {
-	req := newRequest(MethodCall)
-	return d.handleDispatch(req)
-}
-
-func (d *dispatch) dispatchCancel() (err error) {
-	req := newRequest(MethodCancel)
-	if err := decodeIntoRequest(d.receiver, req); err != nil {
-		return err
-	}
-	req.LogInvocation(d.log, nil, nil)
-	d.taskCancelCh <- req.Message().seqno
-	return nil
-}
-
-func (d *dispatch) handleDispatch(req request) error {
-	if err := decodeIntoRequest(d.receiver, req); err != nil {
-		return err
-	}
-
-	m := req.Message()
-	serveHandler, wrapErrorFunc, se := d.findServeHandler(m.method)
-	if se != nil {
-		m.err = wrapError(wrapErrorFunc, se)
-		if err := decodeToNull(d.receiver, m); err != nil {
-			return err
-		}
-		req.LogInvocation(d.log, se, nil)
-		return req.Reply(d.transmitter, d.log)
-	}
-	cancelFunc := req.Serve(d.receiver, d.transmitter, serveHandler, wrapErrorFunc, d.log)
-	if cancelFunc != nil {
-
-	}
-	return nil
-}
-
-// Server
-func (d *dispatch) dispatchResponse() (err error) {
-	m := &message{remainingFields: 3}
-
-	if err = decodeMessage(d.receiver, m, &m.seqno); err != nil {
-		return err
-	}
-
-	d.rmCallCh <- m.seqno
-	call := <-d.callRespCh
-
-	if call == nil {
-		d.log.UnexpectedReply(m.seqno)
-		return decodeToNull(d.receiver, m)
-	}
-
-	var apperr error
-
-	call.profiler.Stop()
-
-	if apperr, err = decodeError(d.receiver, m, call.errorUnwrapper); err == nil {
-		decodeTo := call.res
-		if decodeTo == nil {
-			decodeTo = new(interface{})
-		}
-		err = decodeMessage(d.receiver, m, decodeTo)
-		d.log.ClientReply(m.seqno, call.method, err, decodeTo)
-	} else {
-		d.log.ClientReply(m.seqno, call.method, err, nil)
-	}
-
-	if err != nil {
-		decodeToNull(d.receiver, m)
-		if apperr == nil {
-			apperr = err
-		}
-	}
-
-	call.Finish(apperr)
-
-	return
 }
 
 func wrapError(f WrapErrorFunc, e error) interface{} {

--- a/errors.go
+++ b/errors.go
@@ -75,7 +75,7 @@ type CanceledError struct {
 	p string
 }
 
-func NewCanceledError(method string, seq int) CanceledError {
+func newCanceledError(method string, seq int) CanceledError {
 	return CanceledError{
 		p: fmt.Sprintf("call canceled: method %s, seqid %d", method, seq),
 	}

--- a/packetizer.go
+++ b/packetizer.go
@@ -1,18 +1,22 @@
 package rpc
 
-type packetizer struct {
-	dispatch dispatcher
+type packetizer interface {
+	Packetize() error
+}
+
+type packetHandler struct {
+	receiver receiver
 	dec      byteReadingDecoder
 }
 
-func newPacketizer(d dispatcher, dec byteReadingDecoder) *packetizer {
-	return &packetizer{
-		dispatch: d,
+func newPacketHandler(r receiver, dec byteReadingDecoder) *packetHandler {
+	return &packetHandler{
+		receiver: r,
 		dec:      dec,
 	}
 }
 
-func (p *packetizer) getFrame() (int, error) {
+func (p *packetHandler) getFrame() (int, error) {
 	var l int
 
 	err := p.dec.Decode(&l)
@@ -20,7 +24,9 @@ func (p *packetizer) getFrame() (int, error) {
 	return l, err
 }
 
-func (p *packetizer) getMessage(l int) (err error) {
+func (p *packetHandler) getMessage(l int) (err error) {
+	// TODO currently tossing out `l` above. We should either validate it or
+	// not pass it in at all.
 	var b byte
 
 	if b, err = p.dec.ReadByte(); err != nil {
@@ -29,7 +35,7 @@ func (p *packetizer) getMessage(l int) (err error) {
 	nb := int(b)
 
 	if nb >= 0x91 && nb <= 0x9f {
-		err = p.dispatch.Dispatch(nb - 0x90)
+		err = p.receiver.Receive(nb - 0x90)
 	} else {
 		err = NewPacketizerError("wrong message structure prefix (%d)", nb)
 	}
@@ -37,7 +43,7 @@ func (p *packetizer) getMessage(l int) (err error) {
 	return err
 }
 
-func (p *packetizer) packetizeOne() (err error) {
+func (p *packetHandler) packetizeOne() (err error) {
 	var n int
 	if n, err = p.getFrame(); err == nil {
 		err = p.getMessage(n)
@@ -45,7 +51,7 @@ func (p *packetizer) packetizeOne() (err error) {
 	return
 }
 
-func (p *packetizer) Packetize() (err error) {
+func (p *packetHandler) Packetize() (err error) {
 	for err == nil {
 		err = p.packetizeOne()
 	}

--- a/protocol.go
+++ b/protocol.go
@@ -1,0 +1,31 @@
+package rpc
+
+import (
+	"golang.org/x/net/context"
+)
+
+type ServeHandlerDescription struct {
+	MakeArg    func() interface{}
+	Handler    func(ctx context.Context, arg interface{}) (ret interface{}, err error)
+	MethodType MethodType
+}
+
+type MethodType int
+
+const (
+	MethodCall     MethodType = 0
+	MethodResponse            = 1
+	MethodNotify              = 2
+	MethodCancel              = 3
+)
+
+type ErrorUnwrapper interface {
+	MakeArg() interface{}
+	UnwrapError(arg interface{}) (appError error, dispatchError error)
+}
+
+type Protocol struct {
+	Name      string
+	Methods   map[string]ServeHandlerDescription
+	WrapError WrapErrorFunc
+}

--- a/receiver.go
+++ b/receiver.go
@@ -1,0 +1,250 @@
+package rpc
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+type messageHandler struct {
+	dispatchFunc  func() error
+	messageLength int
+}
+
+type task struct {
+	seqid      int
+	cancelFunc context.CancelFunc
+}
+
+type receiver interface {
+	Receive(l int) error
+	RegisterProtocol(Protocol) error
+	Close(err error) chan struct{}
+	AddCloseListener(chan error)
+}
+
+type callRetrieval struct {
+	seqid int
+	ch    chan *call
+}
+
+type receiveHandler struct {
+	writer encoder
+	reader byteReadingDecoder
+
+	protocols     map[string]Protocol
+	wrapErrorFunc WrapErrorFunc
+	tasks         map[int]context.CancelFunc
+
+	listeners   map[chan error]struct{}
+	listenerMtx sync.Mutex
+
+	// Stops all loops when closed
+	stopCh chan struct{}
+	// Closed once all loops are finished
+	closedCh chan struct{}
+
+	rmCallCh chan callRetrieval
+
+	// Task loop channels
+	taskBeginCh  chan *task
+	taskCancelCh chan int
+	taskEndCh    chan int
+
+	log             LogInterface
+	messageHandlers map[MethodType]messageHandler
+}
+
+func newReceiveHandler(enc encoder, dec byteReadingDecoder, rmCallCh chan callRetrieval, l LogInterface, wef WrapErrorFunc) *receiveHandler {
+	r := &receiveHandler{
+		writer:    enc,
+		reader:    dec,
+		protocols: make(map[string]Protocol),
+		tasks:     make(map[int]context.CancelFunc),
+		listeners: make(map[chan error]struct{}),
+		rmCallCh:  rmCallCh,
+		stopCh:    make(chan struct{}),
+		closedCh:  make(chan struct{}),
+
+		taskBeginCh:  make(chan *task),
+		taskCancelCh: make(chan int),
+		taskEndCh:    make(chan int),
+
+		log:           l,
+		wrapErrorFunc: wef,
+	}
+	r.messageHandlers = map[MethodType]messageHandler{
+		MethodNotify:   {dispatchFunc: r.receiveNotify, messageLength: 3},
+		MethodCall:     {dispatchFunc: r.receiveCall, messageLength: 4},
+		MethodResponse: {dispatchFunc: r.receiveResponse, messageLength: 4},
+		MethodCancel:   {dispatchFunc: r.receiveCancel, messageLength: 3},
+	}
+	go r.taskLoop()
+	return r
+}
+
+func (r *receiveHandler) taskLoop() {
+	tasks := make(map[int]context.CancelFunc)
+	for {
+		select {
+		case <-r.stopCh:
+			close(r.closedCh)
+			return
+		case t := <-r.taskBeginCh:
+			tasks[t.seqid] = t.cancelFunc
+		case seqid := <-r.taskCancelCh:
+			if cancelFunc, ok := tasks[seqid]; ok {
+				cancelFunc()
+			}
+			delete(tasks, seqid)
+		case seqid := <-r.taskEndCh:
+			delete(tasks, seqid)
+		}
+	}
+}
+
+func (r *receiveHandler) findServeHandler(n string) (*ServeHandlerDescription, WrapErrorFunc, error) {
+	p, m := SplitMethodName(n)
+	prot, found := r.protocols[p]
+	if !found {
+		return nil, r.wrapErrorFunc, ProtocolNotFoundError{p}
+	}
+	srv, found := prot.Methods[m]
+	if !found {
+		return nil, r.wrapErrorFunc, MethodNotFoundError{p, m}
+	}
+	return &srv, prot.WrapError, nil
+}
+
+func (d *receiveHandler) Receive(length int) error {
+	var requestType MethodType
+	if err := d.reader.Decode(&requestType); err != nil {
+		return err
+	}
+	handler, ok := d.messageHandlers[requestType]
+	if !ok {
+		return NewDispatcherError("invalid message type")
+	}
+	if length != handler.messageLength {
+		return NewDispatcherError("wrong number of fields for message (got n=%d, expected n=%d)", length, handler.messageLength)
+
+	}
+	return handler.dispatchFunc()
+}
+
+func (r *receiveHandler) receiveNotify() (err error) {
+	req := newRequest(MethodNotify)
+	return r.handleReceiveDispatch(req)
+}
+
+func (r *receiveHandler) receiveCall() error {
+	req := newRequest(MethodCall)
+	return r.handleReceiveDispatch(req)
+}
+
+func (r *receiveHandler) receiveCancel() (err error) {
+	req := newRequest(MethodCancel)
+	if err := decodeIntoRequest(r.reader, req); err != nil {
+		return err
+	}
+	req.LogInvocation(r.log, nil, nil)
+	r.taskCancelCh <- req.Message().seqno
+	return nil
+}
+
+func (r *receiveHandler) handleReceiveDispatch(req request) error {
+	if err := decodeIntoRequest(r.reader, req); err != nil {
+		return err
+	}
+
+	m := req.Message()
+	serveHandler, wrapErrorFunc, se := r.findServeHandler(m.method)
+	if se != nil {
+		m.err = wrapError(wrapErrorFunc, se)
+		if err := decodeToNull(r.reader, m); err != nil {
+			return err
+		}
+		req.LogInvocation(r.log, se, nil)
+		return req.Reply(r.writer, r.log)
+	}
+	cancelFunc := req.Serve(r.reader, r.writer, serveHandler, wrapErrorFunc, r.log)
+	if cancelFunc != nil {
+
+	}
+	return nil
+}
+
+func (r *receiveHandler) receiveResponse() (err error) {
+	m := &message{remainingFields: 3}
+
+	if err = decodeMessage(r.reader, m, &m.seqno); err != nil {
+		return err
+	}
+
+	ch := make(chan *call)
+	r.rmCallCh <- callRetrieval{m.seqno, ch}
+	call := <-ch
+
+	if call == nil {
+		r.log.UnexpectedReply(m.seqno)
+		return decodeToNull(r.reader, m)
+	}
+
+	var apperr error
+
+	call.profiler.Stop()
+
+	if apperr, err = decodeError(r.reader, m, call.errorUnwrapper); err == nil {
+		decodeTo := call.res
+		if decodeTo == nil {
+			decodeTo = new(interface{})
+		}
+		err = decodeMessage(r.reader, m, decodeTo)
+		r.log.ClientReply(m.seqno, call.method, err, decodeTo)
+	} else {
+		r.log.ClientReply(m.seqno, call.method, err, nil)
+	}
+
+	if err != nil {
+		decodeToNull(r.reader, m)
+		if apperr == nil {
+			apperr = err
+		}
+	}
+
+	call.Finish(apperr)
+
+	return
+}
+
+func (r *receiveHandler) RegisterProtocol(p Protocol) (err error) {
+	if _, found := r.protocols[p.Name]; found {
+		err = AlreadyRegisteredError{p.Name}
+	} else {
+		r.protocols[p.Name] = p
+	}
+	return err
+}
+
+func (r *receiveHandler) Close(err error) chan struct{} {
+	close(r.stopCh)
+	r.broadcast(err)
+	return r.closedCh
+}
+
+func (r *receiveHandler) AddCloseListener(ch chan error) {
+	r.listenerMtx.Lock()
+	defer r.listenerMtx.Unlock()
+	r.listeners[ch] = struct{}{}
+}
+
+func (r *receiveHandler) broadcast(err error) {
+	r.listenerMtx.Lock()
+	defer r.listenerMtx.Unlock()
+	for ch := range r.listeners {
+		select {
+		case ch <- err:
+		default:
+		}
+	}
+}

--- a/request.go
+++ b/request.go
@@ -3,18 +3,35 @@ package rpc
 type request interface {
 	Message() *message
 	Reply(encoder, LogInterface) error
+	Serve(byteReadingDecoder, encoder, *ServeHandlerDescription, WrapErrorFunc, LogInterface)
 	LogInvocation(log LogInterface, err error, arg interface{})
 	LogCompletion(log LogInterface, err error)
 }
 
+type requestImpl struct {
+	message
+}
+
+func (req *requestImpl) Message() *message {
+	return &req.message
+}
+
+func (req *requestImpl) getArg(receiver decoder, handler *ServeHandlerDescription) (interface{}, error) {
+	arg := handler.MakeArg()
+	err := decodeMessage(receiver, req.Message(), arg)
+	return arg, err
+}
+
 type callRequest struct {
-	*message
+	requestImpl
 }
 
 func newCallRequest() *callRequest {
 	r := &callRequest{
-		message: &message{
-			remainingFields: 3,
+		requestImpl: requestImpl{
+			message: message{
+				remainingFields: 3,
+			},
 		},
 	}
 	r.decodeSlots = []interface{}{
@@ -22,10 +39,6 @@ func newCallRequest() *callRequest {
 		&r.method,
 	}
 	return r
-}
-
-func (r *callRequest) Message() *message {
-	return r.message
 }
 
 func (r *callRequest) LogInvocation(log LogInterface, err error, arg interface{}) {
@@ -50,24 +63,42 @@ func (r *callRequest) Reply(enc encoder, log LogInterface) error {
 	return err
 }
 
+func (r *callRequest) Serve(receiver byteReadingDecoder, transmitter encoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc, log LogInterface) {
+
+	prof := log.StartProfiler("serve %s", r.method)
+	arg, err := r.getArg(receiver, handler)
+
+	go func() {
+		r.LogInvocation(log, err, arg)
+		if err != nil {
+			r.err = wrapError(wrapErrorFunc, err)
+		} else {
+			res, err := handler.Handler(arg)
+			r.err = wrapError(wrapErrorFunc, err)
+			r.res = res
+		}
+		prof.Stop()
+		r.LogCompletion(log, err)
+		r.Reply(transmitter, log)
+	}()
+}
+
 type notifyRequest struct {
-	*message
+	requestImpl
 }
 
 func newNotifyRequest() *notifyRequest {
 	r := &notifyRequest{
-		message: &message{
-			remainingFields: 2,
+		requestImpl: requestImpl{
+			message: message{
+				remainingFields: 2,
+			},
 		},
 	}
 	r.decodeSlots = []interface{}{
 		&r.method,
 	}
 	return r
-}
-
-func (r *notifyRequest) Message() *message {
-	return r.message
 }
 
 func (r *notifyRequest) LogInvocation(log LogInterface, err error, arg interface{}) {
@@ -82,12 +113,63 @@ func (r *notifyRequest) Reply(enc encoder, log LogInterface) error {
 	return nil
 }
 
+func (r *notifyRequest) Serve(receiver byteReadingDecoder, transmitter encoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc, log LogInterface) {
+
+	prof := log.StartProfiler("serve-notify %s", r.method)
+	arg, err := r.getArg(receiver, handler)
+
+	go func() {
+		r.LogInvocation(log, err, arg)
+		if err == nil {
+			_, err = handler.Handler(arg)
+		}
+		prof.Stop()
+		r.LogCompletion(log, err)
+	}()
+}
+
+type cancelRequest struct {
+	requestImpl
+}
+
+func newCancelRequest() *cancelRequest {
+	r := &cancelRequest{
+		requestImpl: requestImpl{
+			message: message{
+				remainingFields: 2,
+			},
+		},
+	}
+	r.decodeSlots = []interface{}{
+		&r.seqno,
+		&r.method,
+	}
+	return r
+}
+
+func (r *cancelRequest) LogInvocation(log LogInterface, err error, arg interface{}) {
+	log.ServerCancelCall(r.seqno, r.method)
+}
+
+func (r *cancelRequest) LogCompletion(log LogInterface, err error) {
+}
+
+func (r *cancelRequest) Reply(enc encoder, log LogInterface) error {
+	return nil
+}
+
+func (r *cancelRequest) Serve(receiver byteReadingDecoder, transmitter encoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc, log LogInterface) {
+	r.LogInvocation(log, nil, nil)
+}
+
 func newRequest(methodType MethodType) request {
 	switch methodType {
 	case MethodCall:
 		return newCallRequest()
 	case MethodNotify:
 		return newNotifyRequest()
+	case MethodCancel:
+		return newCancelRequest()
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -11,21 +11,21 @@ func NewServer(xp Transporter, f WrapErrorFunc) *Server {
 
 func (s *Server) Register(p Protocol) error {
 	p.WrapError = s.wrapError
-	dispatcher, err := s.xp.getDispatcher()
+	receiver, err := s.xp.getReceiver()
 	if err != nil {
 		return err
 	}
-	return dispatcher.RegisterProtocol(p)
+	return receiver.RegisterProtocol(p)
 }
 
 // AddCloseListener supplies a channel listener to which
 // the server will send an error when a connection closes
 func (s *Server) AddCloseListener(ch chan error) error {
-	dispatcher, err := s.xp.getDispatcher()
+	rec, err := s.xp.getReceiver()
 	if err != nil {
 		return err
 	}
-	dispatcher.AddCloseListener(ch)
+	rec.AddCloseListener(ch)
 	return nil
 }
 


### PR DESCRIPTION
We now cancel on the server side as well when a cancel request is sent.
You can handle the cancellation in your protocol method by receiving from
the `ctx.Done()` channel.

I also separated out the dispatch and receive handlers since they were conceptually different things.