### PR TITLE
Fix RPC cancellation hang bug

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -143,7 +143,9 @@ func (d *dispatch) handleCall(calls map[seqNumber]*call, c *call) {
 				// been processed.
 				return
 			}
-			// TODO: Remove c from calls.
+			// TODO: Remove c from calls:
+			// https://github.com/keybase/go-framed-msgpack-rpc/issues/30
+			// .
 			v := []interface{}{MethodCancel, seqid, c.method}
 			err := d.writer.Encode(v)
 			d.log.ClientCancel(seqid, c.method, err)

--- a/dispatch.go
+++ b/dispatch.go
@@ -143,6 +143,7 @@ func (d *dispatch) handleCall(calls map[seqNumber]*call, c *call) {
 				// been processed.
 				return
 			}
+			// TODO: Remove c from calls.
 			v := []interface{}{MethodCancel, seqid, c.method}
 			err := d.writer.Encode(v)
 			d.log.ClientCancel(seqid, c.method, err)

--- a/dispatch.go
+++ b/dispatch.go
@@ -138,13 +138,14 @@ func (d *dispatch) handleCall(calls map[seqNumber]*call, c *call) {
 		select {
 		case <-c.ctx.Done():
 			setResult := c.Finish(newCanceledError(c.method, seqid))
-			// If setResult is false, then the result of
-			// the call has already been processed.
-			if setResult {
-				v := []interface{}{MethodCancel, seqid, c.method}
-				err := d.writer.Encode(v)
-				d.log.ClientCancel(seqid, c.method, err)
+			if !setResult {
+				// The result of the call has already
+				// been processed.
+				return
 			}
+			v := []interface{}{MethodCancel, seqid, c.method}
+			err := d.writer.Encode(v)
+			d.log.ClientCancel(seqid, c.method, err)
 		case <-c.doneCh:
 		}
 	}()

--- a/dispatch.go
+++ b/dispatch.go
@@ -57,9 +57,16 @@ func newDispatch(enc encoder, dec byteReadingDecoder, callRetrievalCh chan callR
 }
 
 type call struct {
-	ctx            context.Context
-	ch             chan error
-	doneCh         chan struct{}
+	ctx context.Context
+
+	// resultCh serializes the possible results generated for this
+	// call, with the first one becoming the true result.
+	resultCh chan error
+
+	// doneCh is closed when the true result for this call is
+	// chosen.
+	doneCh chan struct{}
+
 	method         string
 	seqid          seqNumber
 	arg            interface{}
@@ -71,7 +78,7 @@ type call struct {
 func newCall(ctx context.Context, m string, arg interface{}, res interface{}, u ErrorUnwrapper, p Profiler) *call {
 	return &call{
 		ctx:            ctx,
-		ch:             make(chan error),
+		resultCh:       make(chan error),
 		doneCh:         make(chan struct{}),
 		method:         m,
 		arg:            arg,
@@ -81,12 +88,15 @@ func newCall(ctx context.Context, m string, arg interface{}, res interface{}, u 
 	}
 }
 
-func (c *call) Finish(err error) {
-	// Ensure we only send a response if something is waiting on c.ch
+// Finish tries to set the given error as the result of this call, and
+// returns whether or not this was successful.
+func (c *call) Finish(err error) bool {
 	select {
-	case c.ch <- err:
+	case c.resultCh <- err:
 		close(c.doneCh)
+		return true
 	case <-c.doneCh:
+		return false
 	}
 }
 
@@ -96,7 +106,7 @@ func (d *dispatch) callLoop() {
 		select {
 		case <-d.stopCh:
 			for _, c := range calls {
-				c.Finish(io.EOF)
+				_ = c.Finish(io.EOF)
 			}
 			close(d.closedCh)
 			return
@@ -117,14 +127,15 @@ func (d *dispatch) handleCall(calls map[seqNumber]*call, c *call) {
 	v := []interface{}{MethodCall, seqid, c.method, c.arg}
 	err := d.writer.Encode(v)
 	if err != nil {
-		c.Finish(err)
+		// TODO: Check this.
+		_ = c.Finish(err)
 		return
 	}
 	d.log.ClientCall(seqid, c.method, c.arg)
 	go func() {
 		select {
 		case <-c.ctx.Done():
-			c.ch <- newCanceledError(c.method, seqid)
+			c.resultCh <- newCanceledError(c.method, seqid)
 			v := []interface{}{MethodCancel, seqid, c.method}
 			err := d.writer.Encode(v)
 			d.log.ClientCancel(seqid, c.method, err)
@@ -143,7 +154,7 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 	profiler := d.log.StartProfiler("call %s", name)
 	call := newCall(ctx, name, arg, res, u, profiler)
 	d.callCh <- call
-	return <-call.ch
+	return <-call.resultCh
 }
 
 func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}) error {

--- a/dispatch.go
+++ b/dispatch.go
@@ -127,8 +127,10 @@ func (d *dispatch) handleCall(calls map[seqNumber]*call, c *call) {
 	v := []interface{}{MethodCall, seqid, c.method, c.arg}
 	err := d.writer.Encode(v)
 	if err != nil {
-		// TODO: Check this.
-		_ = c.Finish(err)
+		setResult := c.Finish(err)
+		if !setResult {
+			panic("c.Finish unexpectedly returned false")
+		}
 		return
 	}
 	d.log.ClientCall(seqid, c.method, c.arg)

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -69,6 +69,27 @@ func TestDispatchCanceledBeforeResult(t *testing.T) {
 	<-closed
 }
 
+func TestDispatchCanceledAfterResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d, callCh, done := dispatchTestCallWithContext(t, ctx)
+
+	ch := make(chan *call)
+	callCh <- callRetrieval{0, ch}
+	c := <-ch
+	require.NotNil(t, c, "Expected c not to be nil")
+
+	ok := c.Finish(nil)
+	require.True(t, ok, "Expected c.Finish to succeed")
+
+	cancel()
+
+	err := <-done
+	require.Nil(t, err, "Expected no error")
+
+	closed := d.Close(nil)
+	<-closed
+}
+
 func TestDispatchEOF(t *testing.T) {
 	d, _, done := dispatchTestCall(t)
 

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -34,7 +34,8 @@ func TestDispatchSuccessfulCall(t *testing.T) {
 	c := <-ch
 	require.NotNil(t, c, "Expected c not to be nil")
 
-	c.Finish(nil)
+	// TODO: Check this.
+	_ = c.Finish(nil)
 	err := <-done
 	require.Nil(t, err, "Expected no error")
 

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -34,8 +34,8 @@ func TestDispatchSuccessfulCall(t *testing.T) {
 	c := <-ch
 	require.NotNil(t, c, "Expected c not to be nil")
 
-	// TODO: Check this.
-	_ = c.Finish(nil)
+	ok := c.Finish(nil)
+	require.True(t, ok, "Expected c.Finish to succeed")
 	err := <-done
 	require.Nil(t, err, "Expected no error")
 

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func dispatchTestCall(t *testing.T) (dispatcher, chan callRetrieval, chan error) {
+func dispatchTestCallWithContext(t *testing.T, ctx context.Context) (dispatcher, chan callRetrieval, chan error) {
 	dispatchOut := newBlockingMockCodec()
 
 	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
@@ -16,7 +16,7 @@ func dispatchTestCall(t *testing.T) (dispatcher, chan callRetrieval, chan error)
 	d := newDispatch(dispatchOut, newBlockingMockCodec(), callCh, logFactory.NewLog(nil))
 
 	done := runInBg(func() error {
-		return d.Call(context.Background(), "whatever", new(interface{}), new(interface{}), nil)
+		return d.Call(ctx, "whatever", new(interface{}), new(interface{}), nil)
 	})
 
 	// Necessary to ensure the call is far enough along to
@@ -24,6 +24,10 @@ func dispatchTestCall(t *testing.T) (dispatcher, chan callRetrieval, chan error)
 	decoderErr := decodeToNull(dispatchOut, &message{remainingFields: 4})
 	require.Nil(t, decoderErr, "Expected no error")
 	return d, callCh, done
+}
+
+func dispatchTestCall(t *testing.T) (dispatcher, chan callRetrieval, chan error) {
+	return dispatchTestCallWithContext(t, context.Background())
 }
 
 func TestDispatchSuccessfulCall(t *testing.T) {
@@ -38,6 +42,28 @@ func TestDispatchSuccessfulCall(t *testing.T) {
 	require.True(t, ok, "Expected c.Finish to succeed")
 	err := <-done
 	require.Nil(t, err, "Expected no error")
+
+	closed := d.Close(nil)
+	<-closed
+}
+
+func TestDispatchCanceledBeforeResult(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d, callCh, done := dispatchTestCallWithContext(t, ctx)
+
+	ch := make(chan *call)
+	callCh <- callRetrieval{0, ch}
+	c := <-ch
+	require.NotNil(t, c, "Expected c not to be nil")
+
+	cancel()
+
+	err := <-done
+	_, canceled := err.(CanceledError)
+	require.True(t, canceled, "Expected rpc.CanceledError")
+
+	ok := c.Finish(nil)
+	require.False(t, ok, "Expected c.Finish to fail")
 
 	closed := d.Close(nil)
 	<-closed

--- a/receiver.go
+++ b/receiver.go
@@ -211,7 +211,7 @@ func (r *receiveHandler) receiveResponse() (err error) {
 		}
 	}
 
-	call.Finish(apperr)
+	_ = call.Finish(apperr)
 
 	return
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -134,7 +134,7 @@ func TestReceiveResponse(t *testing.T) {
 	callRetrieval := <-callCh
 	callRetrieval.ch <- c
 
-	<-c.ch
+	<-c.resultCh
 	require.Equal(t, "hi", result, "Expected response to say \"hi\"")
 }
 
@@ -193,7 +193,7 @@ func TestReceiveResponseError(t *testing.T) {
 	callRetrieval := <-callCh
 	callRetrieval.ch <- c
 
-	err := <-c.ch
+	err := <-c.resultCh
 	require.EqualError(t, err, "Tried to decode incorrect type. Expected: string, actual: int", "expected error when passing in a nil call")
 	err = <-done
 	require.EqualError(t, err, "Tried to decode incorrect type. Expected: string, actual: int", "expected error when passing in a nil call")

--- a/request.go
+++ b/request.go
@@ -75,7 +75,9 @@ func (r *callRequest) Reply(enc encoder, log LogInterface) error {
 	var err error
 	select {
 	case <-r.ctx.Done():
+		// TODO: Use newCanceledError.
 		err = fmt.Errorf("call canceled for seqno %d", r.seqno)
+		// TODO: Use log.Info instead.
 		log.Warning(err.Error())
 	default:
 		v := []interface{}{

--- a/request.go
+++ b/request.go
@@ -75,9 +75,10 @@ func (r *callRequest) Reply(enc encoder, log LogInterface) error {
 	var err error
 	select {
 	case <-r.ctx.Done():
-		// TODO: Use newCanceledError.
+		// TODO: Use newCanceledError and log.Info:
+		// https://github.com/keybase/go-framed-msgpack-rpc/issues/29
+		// .
 		err = fmt.Errorf("call canceled for seqno %d", r.seqno)
-		// TODO: Use log.Info instead.
 		log.Warning(err.Error())
 	default:
 		v := []interface{}{


### PR DESCRIPTION
Otherwise, if an RPC is cancelled before the server
result is returned returned, this will cause a hang.

Also add tests.