### PR TITLE
GetCloseBroadcaster is a buffered, broadcast channel of when the transport closes

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -18,6 +18,7 @@ type Transporter interface {
 	IsConnected() bool
 	AddCloseListener(ch chan<- error)
 	RegisterProtocol(p Protocol) error
+	GetCloseBroadcaster() <-chan struct{}
 }
 
 type transporter interface {
@@ -39,6 +40,10 @@ func newConnDecoder(c net.Conn) *connDecoder {
 		Reader:  br,
 		decoder: codec.NewDecoder(br, mh),
 	}
+}
+
+func (t *transport) GetCloseBroadcaster() <-chan struct{} {
+	return t.stopCh
 }
 
 var _ transporter = (*transport)(nil)


### PR DESCRIPTION
- is easier to use than AddCloseListener