### PR TITLE
Split Run into Run and RunAsync

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -13,7 +13,7 @@ type task struct {
 
 type receiver interface {
 	Receive(rpcMessage) error
-	Close() chan struct{}
+	Close()
 }
 
 type receiveHandler struct {
@@ -138,7 +138,7 @@ func (r *receiveHandler) receiveResponse(rpc *rpcResponseMessage) (err error) {
 	return nil
 }
 
-func (r *receiveHandler) Close() chan struct{} {
+func (r *receiveHandler) Close() {
 	close(r.stopCh)
-	return r.closedCh
+	<-r.closedCh
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -114,13 +114,9 @@ func TestCloseReceiver(t *testing.T) {
 			nil,
 		),
 	)
-	// Receiver error status
-	errCh := make(chan error, 1)
-	receiver.AddCloseListener(errCh)
-	receiver.Close(io.EOF)
-	err := <-errCh
-	require.EqualError(t, err, io.EOF.Error())
+	closeCh := receiver.Close(io.EOF)
+	<-closeCh
 
-	err = <-waitCh
+	err := <-waitCh
 	require.EqualError(t, err, context.Canceled.Error())
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -113,8 +113,7 @@ func TestCloseReceiver(t *testing.T) {
 			nil,
 		),
 	)
-	closeCh := receiver.Close()
-	<-closeCh
+	receiver.Close()
 
 	err := <-waitCh
 	require.EqualError(t, err, context.Canceled.Error())

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -113,7 +113,7 @@ func TestCloseReceiver(t *testing.T) {
 			nil,
 		),
 	)
-	receiver.Close()
+	<-receiver.Close()
 
 	err := <-waitCh
 	require.EqualError(t, err, context.Canceled.Error())

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"io"
 	"net"
 	"testing"
 
@@ -114,7 +113,7 @@ func TestCloseReceiver(t *testing.T) {
 			nil,
 		),
 	)
-	closeCh := receiver.Close(io.EOF)
+	closeCh := receiver.Close()
 	<-closeCh
 
 	err := <-waitCh

--- a/server.go
+++ b/server.go
@@ -14,13 +14,6 @@ func (s *Server) Register(p Protocol) error {
 	return s.xp.RegisterProtocol(p)
 }
 
-// AddCloseListener supplies a channel listener to which
-// the server will send an error when a connection closes
-func (s *Server) AddCloseListener(ch chan error) error {
-	s.xp.AddCloseListener(ch)
-	return nil
-}
-
 func (s *Server) Run() error {
 	return s.xp.Run()
 }

--- a/server.go
+++ b/server.go
@@ -21,11 +21,10 @@ func (s *Server) AddCloseListener(ch chan error) error {
 	return nil
 }
 
-// TODO: Split into Run and RunAsync, and update callers. See
-// https://github.com/keybase/go-framed-msgpack-rpc/issues/39 .
-func (s *Server) Run(bg bool) error {
-	if bg {
-		return s.xp.RunAsync()
-	}
+func (s *Server) Run() error {
 	return s.xp.Run()
+}
+
+func (s *Server) RunAsync() <-chan error {
+	return s.xp.RunAsync()
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -38,7 +38,7 @@ func (s *server) Run(ready chan struct{}, externalListener chan error) (err erro
 		srv := NewServer(xp, nil)
 		srv.Register(createTestProtocol(newTestProtocol(c)))
 		srv.AddCloseListener(closeListener)
-		srv.Run(true)
+		srv.RunAsync()
 	}
 	return nil
 }

--- a/test_utils.go
+++ b/test_utils.go
@@ -22,11 +22,6 @@ func (s *server) Run(ready chan struct{}, externalListener chan error) (err erro
 	if listener, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", s.port)); err != nil {
 		return
 	}
-	closeListener := make(chan error)
-	go func() {
-		<-closeListener
-		listener.Close()
-	}()
 	close(ready)
 	for {
 		var c net.Conn
@@ -37,8 +32,11 @@ func (s *server) Run(ready chan struct{}, externalListener chan error) (err erro
 		xp := NewTransport(c, lf, nil)
 		srv := NewServer(xp, nil)
 		srv.Register(createTestProtocol(newTestProtocol(c)))
-		srv.AddCloseListener(closeListener)
-		srv.RunAsync()
+		errCh := srv.RunAsync()
+		go func() {
+			<-errCh
+			listener.Close()
+		}()
 	}
 	return nil
 }

--- a/transport.go
+++ b/transport.go
@@ -139,7 +139,7 @@ func (t *transport) run() error {
 	// close it before terminating our loops
 	close(t.stopCh)
 	t.dispatcher.Close()
-	t.receiver.Close()
+	<-t.receiver.Close()
 
 	// First inform the encoder that it should close
 	encoderClosed := t.enc.Close()

--- a/transport.go
+++ b/transport.go
@@ -16,7 +16,6 @@ type Transporter interface {
 	Run() error
 	RunAsync() <-chan error
 	IsConnected() bool
-	AddCloseListener(ch chan<- error)
 	RegisterProtocol(p Protocol) error
 }
 
@@ -140,7 +139,7 @@ func (t *transport) run() error {
 	// close it before terminating our loops
 	close(t.stopCh)
 	t.dispatcher.Close()
-	<-t.receiver.Close(err)
+	<-t.receiver.Close()
 
 	// First inform the encoder that it should close
 	encoderClosed := t.enc.Close()
@@ -168,10 +167,6 @@ func (t *transport) getReceiver() (receiver, error) {
 
 func (t *transport) RegisterProtocol(p Protocol) error {
 	return t.protocols.registerProtocol(p)
-}
-
-func (t *transport) AddCloseListener(ch chan<- error) {
-	t.receiver.AddCloseListener(ch)
 }
 
 func shouldContinue(err error) bool {

--- a/transport.go
+++ b/transport.go
@@ -139,7 +139,7 @@ func (t *transport) run() error {
 	// close it before terminating our loops
 	close(t.stopCh)
 	t.dispatcher.Close()
-	<-t.receiver.Close()
+	t.receiver.Close()
 
 	// First inform the encoder that it should close
 	encoderClosed := t.enc.Close()


### PR DESCRIPTION
Make RunAsync return an errCh, and remove
AddCloseListener in favor of that.

AddCloseListener is tricky to use, and
having RunAsync return an errCh is easier
to get right.