### PR TITLE
Add ParseFMPURI for parsing URIs with schemes 'fmprpc' or 'fmprpc+tls'

### DIFF
--- a/fmp_uri.go
+++ b/fmp_uri.go
@@ -1,0 +1,67 @@
+package rpc
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+)
+
+type fmpURIScheme string
+
+const (
+	fmpSchemeStandard fmpURIScheme = "fmprpc"
+	fmpSchemeTLS      fmpURIScheme = "fmprpc+tls"
+)
+
+type FMPURI struct {
+	Scheme   fmpURIScheme
+	HostPort string
+	Host     string
+}
+
+var errInvalidFMPScheme = errors.New("invalid framed msgpack rpc scheme")
+var errNoHost = errors.New("missing host in framed msgpack rpc URI")
+
+func ParseFMPURI(s string) (*FMPURI, error) {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	f := &FMPURI{HostPort: uri.Host}
+
+	switch f.Scheme = fmpURIScheme(uri.Scheme); f.Scheme {
+	case fmpSchemeStandard, fmpSchemeTLS:
+	default:
+		return nil, fmt.Errorf("invalid framed msgpack rpc scheme %s", uri.Scheme)
+	}
+
+	host, _, err := net.SplitHostPort(f.HostPort)
+	if err != nil {
+		return nil, err
+	}
+	if len(host) == 0 {
+		return nil, fmt.Errorf("missing host in address %s", f.HostPort)
+	}
+	f.Host = host
+
+	return f, nil
+}
+
+func (f *FMPURI) UseTLS() bool {
+	return f.Scheme == fmpSchemeTLS
+}
+
+func (f *FMPURI) String() string {
+	return fmt.Sprintf("%s://%s", f.Scheme, f.Host)
+}
+
+func (f *FMPURI) Dial() (net.Conn, error) {
+	network, addr := "tcp", f.HostPort
+	if f.UseTLS() {
+		return tls.Dial(network, addr, nil)
+	}
+	return net.Dial(network, addr)
+}

--- a/fmp_uri_test.go
+++ b/fmp_uri_test.go
@@ -1,0 +1,51 @@
+package rpc
+
+import "testing"
+
+type fmpURITest struct {
+	in  string
+	out *FMPURI
+	err string
+	tls bool
+}
+
+var fmpURITests = []fmpURITest{
+	{in: "fmprpc://gregor.api.keybase.io:80", out: &FMPURI{Scheme: fmpSchemeStandard, HostPort: "gregor.api.keybase.io:80", Host: "gregor.api.keybase.io"}},
+	{in: "fmprpc+tls://gregor.api.keybase.io:443", out: &FMPURI{Scheme: fmpSchemeTLS, HostPort: "gregor.api.keybase.io:443", Host: "gregor.api.keybase.io"}, tls: true},
+	{in: "fmprpc+tls://gregor.api.keybase.io:80", out: &FMPURI{Scheme: fmpSchemeTLS, HostPort: "gregor.api.keybase.io:80", Host: "gregor.api.keybase.io"}, tls: true},
+	{in: "fmprpc://gregor.api.keybase.io:443", out: &FMPURI{Scheme: fmpSchemeStandard, HostPort: "gregor.api.keybase.io:443", Host: "gregor.api.keybase.io"}},
+	{in: "https://gregor.api.keybase.io:443", err: "invalid framed msgpack rpc scheme https"},
+	{in: "fmprpc://gregor.api.keybase.io", err: "missing port in address gregor.api.keybase.io"},
+	{in: "fmprpc+tls://gregor.api.keybase.io", err: "missing port in address gregor.api.keybase.io"},
+	{in: "fmprpc+tls://:443", err: "missing host in address :443"},
+}
+
+func TestParseFMPURI(t *testing.T) {
+	for _, test := range fmpURITests {
+		u, err := ParseFMPURI(test.in)
+		if err != nil {
+			if test.err == "" {
+				t.Errorf("Parse(%q) error: %v, expected no error", test.in, err)
+			}
+			if err.Error() != test.err {
+				t.Errorf("Parse(%q) error: %v, expected %v", test.in, err, test.err)
+			}
+			continue
+		} else if test.err != "" {
+			t.Errorf("Parse(%q) no error, expected %v", test.in, test.err)
+			continue
+		}
+		if u.Scheme != test.out.Scheme {
+			t.Errorf("Parse(%q) scheme: %q, expected %q", test.in, u.Scheme, test.out.Scheme)
+		}
+		if u.Host != test.out.Host {
+			t.Errorf("Parse(%q) host: %q, expected %q", test.in, u.Host, test.out.Host)
+		}
+		if u.HostPort != test.out.HostPort {
+			t.Errorf("Parse(%q) host: %q, expected %q", test.in, u.Host, test.out.Host)
+		}
+		if u.UseTLS() != test.tls {
+			t.Errorf("Parse(%q) use tls: %v, expected %v", test.in, u.UseTLS(), test.tls)
+		}
+	}
+}


### PR DESCRIPTION
Copied with minor modifications from
https://github.com/keybase/client/blob/master/go/service/rpc.go
https://github.com/keybase/client/blob/master/go/service/rpc_test.go

r? @patrickxb @maxtaco @jzila @akalin-keybase 