### PR TITLE
Add Done() and Err() methods to Transport

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -30,13 +30,13 @@ func (s *server) Run(ready chan struct{}, externalListener chan error) (err erro
 			return
 		}
 		xp := NewTransport(c, lf, nil)
-		srv := NewServer(xp, nil)
-		srv.Register(createTestProtocol(newTestProtocol(c)))
-		errCh := srv.RunAsync()
 		go func() {
-			<-errCh
+			<-xp.Done()
 			listener.Close()
 		}()
+		srv := NewServer(xp, nil)
+		srv.Register(createTestProtocol(newTestProtocol(c)))
+		srv.RunAsync()
 	}
 	return nil
 }

--- a/transport.go
+++ b/transport.go
@@ -171,7 +171,8 @@ func (t *transport) run() error {
 	// Log packetizer completion
 	t.log.TransportError(err)
 
-	// Do this before closing stopCh so that Err() sees it.
+	// This must happen before stopCh is closed to have a correct
+	// ordering.
 	t.stopErr = err
 
 	// Since the receiver might require the transport, we have to


### PR DESCRIPTION
This is a better replacement for
AddCloseListener() than checking the return
value of Run() or RunAsync(), which is also
hard to get right.