### PR TITLE
Remove workaround for lack of cancel support

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -369,12 +369,10 @@ func (c *Connection) DoCommand(ctx context.Context, name string,
 				defer c.mutex.Unlock()
 				return c.client
 			}()
-			// try the rpc call. this can also be canceled
-			// by the caller, and will retry connectivity
-			// errors w/backoff.
-			throttleErr := runUnlessCanceled(ctx, func() error {
-				return rpcFunc(rawClient)
-			})
+			// try the rpc call, assuming that it exits
+			// immediately when ctx is canceled. will
+			// retry connectivity errors w/backoff.
+			throttleErr := rpcFunc(rawClient)
 			if throttleErr != nil && c.handler.ShouldRetry(name, throttleErr) {
 				return throttleErr
 			}


### PR DESCRIPTION
runUnlessCanceled was a workaround for when
RPC didn't obey canceled contexts. Now that it
does, we don't need it for RPC calls anymore.