### PR TITLE
demote debug level in OnConnect failure case

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -341,7 +341,7 @@ func (c *Connection) connect(ctx context.Context) error {
 	// connect
 	transport, err := c.transport.Dial(ctx)
 	if err != nil {
-		c.log.Debug("Connection: error dialing transport: %#v", err)
+		c.log.Warning("Connection: error dialing transport: %s", err)
 		return err
 	}
 
@@ -355,7 +355,7 @@ func (c *Connection) connect(ctx context.Context) error {
 	// call the connect handler
 	err = c.handler.OnConnect(ctx, c, client, server)
 	if err != nil {
-		c.log.Debug("Connection: error calling OnConnect handler: %#v", err)
+		c.log.Warning("Connection: error calling OnConnect handler: %s", err)
 		return err
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -341,7 +341,7 @@ func (c *Connection) connect(ctx context.Context) error {
 	// connect
 	transport, err := c.transport.Dial(ctx)
 	if err != nil {
-		c.log.Warning("Connection: error dialing transport: %#v", err)
+		c.log.Debug("Connection: error dialing transport: %#v", err)
 		return err
 	}
 
@@ -355,7 +355,7 @@ func (c *Connection) connect(ctx context.Context) error {
 	// call the connect handler
 	err = c.handler.OnConnect(ctx, c, client, server)
 	if err != nil {
-		c.log.Warning("Connection: error calling OnConnect handler: %#v", err)
+		c.log.Debug("Connection: error calling OnConnect handler: %#v", err)
 		return err
 	}
 


### PR DESCRIPTION
@maxtaco @jzila I'd like to demote these messages to `Debug`, otherwise they get printed out if the client daemon has trouble connecting to Gregor. What do you think?

See: https://github.com/keybase/client/issues/3028#issuecomment-224641128