### PR TITLE
copy the RPC tags before returning to avoid map concurrency errors

### DIFF
--- a/rpc/context.go
+++ b/rpc/context.go
@@ -1,8 +1,6 @@
 package rpc
 
-import (
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // CtxRpcKey is a type defining the context key for the RPC context
 type CtxRpcKey int
@@ -21,16 +19,23 @@ func AddRpcTagsToContext(ctx context.Context, logTagsToAdd CtxRpcTags) context.C
 	currTags, ok := RpcTagsFromContext(ctx)
 	if !ok {
 		currTags = make(CtxRpcTags)
-		ctx = context.WithValue(ctx, CtxRpcTagsKey, currTags)
 	}
 	for key, tag := range logTagsToAdd {
 		currTags[key] = tag
 	}
-	return ctx
+
+	return context.WithValue(ctx, CtxRpcTagsKey, currTags)
 }
 
 // RpcTagsFromContext returns the tags being passed along with the given context.
 func RpcTagsFromContext(ctx context.Context) (CtxRpcTags, bool) {
 	logTags, ok := ctx.Value(CtxRpcTagsKey).(CtxRpcTags)
-	return logTags, ok
+	if ok {
+		ret := make(CtxRpcTags)
+		for k, v := range logTags {
+			ret[k] = v
+		}
+		return ret, true
+	}
+	return nil, false
 }


### PR DESCRIPTION
Let's say you have the following series of calls, where the service sets RPC log tags:

```
                  / -> mdserver
service -> KBFS -> 
                  \ -> mdserver                      
```

KBFS gets itself into a race here when calling `AddRpcTagsToContext` since both calls to mdserver are going to be writing into the same map. 

Fix the problem by making a copy of the map in `RpcTagsFromContext`, and loading a new map in `AddRpcTagsToContext` instead of writing into the map that is already in there.

cc @maxtaco 