### PR TITLE
connection: backoffs should be unique for every call

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -248,6 +248,11 @@ type Connection struct {
 // This struct contains all the connection parameters that are optional. The
 // mandatory parameters are given as positional arguments to the different
 // wrapper functions, along with this struct.
+//
+// The backoffs are functions that created backoff.BackOffs, rather
+// than backoff instances, since some backoffs can be stateful and not
+// goroutine-safe (e.g., backoff.Exponential).  Connection will call
+// these functions once for each command call and reconnect attempt.
 type ConnectionOpts struct {
 	TagsFunc         LogTagsFromContext
 	Protocols        []Protocol

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -106,12 +106,15 @@ func TestReconnectBasic(t *testing.T) {
 		errToThrow: errors.New("intentional error to trigger reconnect"),
 	}
 	output := testLogOutput{t}
-	reconnectBackoff := backoff.NewExponentialBackOff()
-	reconnectBackoff.InitialInterval = 5 * time.Millisecond
+	reconnectBackoffFn := func() backoff.BackOff {
+		reconnectBackoff := backoff.NewExponentialBackOff()
+		reconnectBackoff.InitialInterval = 5 * time.Millisecond
+		return reconnectBackoff
+	}
 	opts := ConnectionOpts{
 		WrapErrorFunc:    testWrapError,
 		TagsFunc:         testLogTags,
-		ReconnectBackoff: reconnectBackoff,
+		ReconnectBackoff: reconnectBackoffFn,
 	}
 	conn := NewConnectionWithTransport(unitTester, unitTester,
 		testErrorUnwrapper{}, output, opts)
@@ -164,12 +167,15 @@ func TestDoCommandThrottle(t *testing.T) {
 
 	throttleErr := errors.New("throttle")
 	output := testLogOutput{t}
-	commandBackoff := backoff.NewExponentialBackOff()
-	commandBackoff.InitialInterval = 5 * time.Millisecond
+	commandBackoffFn := func() backoff.BackOff {
+		commandBackoff := backoff.NewExponentialBackOff()
+		commandBackoff.InitialInterval = 5 * time.Millisecond
+		return commandBackoff
+	}
 	opts := ConnectionOpts{
 		WrapErrorFunc:  testWrapError,
 		TagsFunc:       testLogTags,
-		CommandBackoff: commandBackoff,
+		CommandBackoff: commandBackoffFn,
 	}
 	conn := NewConnectionWithTransport(unitTester, unitTester,
 		testErrorUnwrapper{}, output, opts)


### PR DESCRIPTION
Since exponential backoffs are stateful and non-goroutine-safe.