### PR TITLE
client: move tagsFunc into client

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -368,7 +368,7 @@ func (c *Connection) connect(ctx context.Context) error {
 		return err
 	}
 
-	client := NewClient(transport, c.errorUnwrapper)
+	client := NewClient(transport, c.errorUnwrapper, c.tagsFunc)
 	server := NewServer(transport, c.wef)
 
 	for _, p := range c.protocols {
@@ -581,18 +581,6 @@ var _ GenericClient = connectionClient{}
 
 func (c connectionClient) Call(ctx context.Context, s string, args interface{}, res interface{}) error {
 	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {
-		if c.conn.tagsFunc != nil {
-			tags, ok := c.conn.tagsFunc(ctx)
-			if ok {
-				rpcTags := make(CtxRpcTags)
-				for key, tagName := range tags {
-					if v := ctx.Value(key); v != nil {
-						rpcTags[tagName] = v
-					}
-				}
-				ctx = AddRpcTagsToContext(ctx, rpcTags)
-			}
-		}
 		return rawClient.Call(ctx, s, args, res)
 	})
 }

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -37,7 +37,7 @@ func prepClient(t *testing.T) (TestClient, net.Conn) {
 	require.Nil(t, err, "a dialer error occurred")
 
 	xp := NewTransport(c, nil, nil)
-	return TestClient{GenericClient: NewClient(xp, nil)}, c
+	return TestClient{GenericClient: NewClient(xp, nil, nil)}, c
 }
 
 func prepTest(t *testing.T) (TestClient, chan error, net.Conn) {


### PR DESCRIPTION
So it can be used for non-connections (e.g., when a connection receiver wants to make calls back into the connection initiator).

Issue: KBFS-2035