### PR TITLE
add option to disable SIGPIPE on BSD-like systems

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -188,7 +188,10 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 		}
 
 		// connect
-		baseConn, err := net.Dial("tcp", ct.srvAddr)
+		dialer := net.Dialer{
+			KeepAlive: 10 * time.Second,
+		}
+		baseConn, err := dialer.Dial("tcp", ct.srvAddr)
 		if err != nil {
 			return err
 		}

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -79,7 +79,7 @@ func (t *connTransport) Dial(context.Context) (Transporter, error) {
 
 	// If the client has requested to disable SIGPIPE, then do so now
 	if t.disableSigPipe {
-		if err = disableSigPipe(t.conn); err != nil {
+		if err = DisableSigPipe(t.conn); err != nil {
 			return nil, err
 		}
 	}
@@ -201,7 +201,7 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 		// this somewhat janky method below. See:
 		// https://github.com/golang/go/issues/17393
 		if ct.disableSigPipe {
-			err = disableSigPipe(baseConn)
+			err = DisableSigPipe(baseConn)
 		}
 		return err
 	})

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -56,6 +56,7 @@ type connTransport struct {
 	conn            net.Conn
 	transport       Transporter
 	stagedTransport Transporter
+	disableSigPipe  bool
 }
 
 var _ ConnectionTransport = (*connTransport)(nil)
@@ -75,6 +76,14 @@ func (t *connTransport) Dial(context.Context) (Transporter, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// If the client has requested to disable SIGPIPE, then do so now
+	if t.disableSigPipe {
+		if err = disableSigPipe(t.conn); err != nil {
+			return nil, err
+		}
+	}
+
 	t.stagedTransport = NewTransport(t.conn, t.l, t.wef)
 	return t.stagedTransport, nil
 }
@@ -130,9 +139,10 @@ type ConnectionHandler interface {
 // ConnectionTransportTLS is a ConnectionTransport implementation that
 // uses TLS+rpc.
 type ConnectionTransportTLS struct {
-	rootCerts []byte
-	srvAddr   string
-	tlsConfig *tls.Config
+	rootCerts      []byte
+	srvAddr        string
+	tlsConfig      *tls.Config
+	disableSigPipe bool
 
 	// Protects everything below.
 	mutex           sync.Mutex
@@ -152,6 +162,10 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 	var conn net.Conn
 	err := runUnlessCanceled(ctx, func() error {
 		config := ct.tlsConfig
+		host, _, err := net.SplitHostPort(ct.srvAddr)
+		if err != nil {
+			return err
+		}
 
 		// If we didn't specify a tls.Config, but we did specify
 		// explicit rootCerts, then populate a new tls.Config here.
@@ -162,13 +176,30 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			if !certs.AppendCertsFromPEM(ct.rootCerts) {
 				return errors.New("Unable to load root certificates")
 			}
-			config = &tls.Config{RootCAs: certs}
+			config = &tls.Config{
+				RootCAs:    certs,
+				ServerName: host,
+			}
 		}
+		// Final check to make sure we have a TLS config since tls.Client requires
+		// either ServerName or InsecureSkipVerify to be set
+		if config == nil {
+			config = &tls.Config{ServerName: host}
+		}
+
 		// connect
-		var err error
-		conn, err = tls.DialWithDialer(&net.Dialer{
-			KeepAlive: 10 * time.Second,
-		}, "tcp", ct.srvAddr, config)
+		baseConn, err := net.Dial("tcp", ct.srvAddr)
+		if err != nil {
+			return err
+		}
+		conn = tls.Client(baseConn, config)
+
+		// If the client has requested we disable SIGPIPE for this connection, then do it using
+		// this somewhat janky method below. See:
+		// https://github.com/golang/go/issues/17393
+		if ct.disableSigPipe {
+			err = disableSigPipe(baseConn)
+		}
 		return err
 	})
 	if err != nil {
@@ -260,6 +291,7 @@ type ConnectionOpts struct {
 	WrapErrorFunc    WrapErrorFunc
 	ReconnectBackoff func() backoff.BackOff
 	CommandBackoff   func() backoff.BackOff
+	DisableSigPipe   bool
 }
 
 // NewTLSConnection returns a connection that tries to connect to the
@@ -274,10 +306,11 @@ func NewTLSConnection(
 	opts ConnectionOpts,
 ) *Connection {
 	transport := &ConnectionTransportTLS{
-		rootCerts:  rootCerts,
-		srvAddr:    srvAddr,
-		logFactory: logFactory,
-		wef:        opts.WrapErrorFunc,
+		rootCerts:      rootCerts,
+		srvAddr:        srvAddr,
+		logFactory:     logFactory,
+		wef:            opts.WrapErrorFunc,
+		disableSigPipe: opts.DisableSigPipe,
 	}
 	return newConnectionWithTransportAndProtocols(handler, transport, errorUnwrapper, logOutput, opts)
 }

--- a/rpc/sigpipe.go
+++ b/rpc/sigpipe.go
@@ -4,6 +4,6 @@ package rpc
 
 import "net"
 
-func disableSigPipe(c net.Conn) error {
+func DisableSigPipe(c net.Conn) error {
 	return nil
 }

--- a/rpc/sigpipe.go
+++ b/rpc/sigpipe.go
@@ -1,0 +1,9 @@
+// +build !darwin
+
+package rpc
+
+import "net"
+
+func disableSigPipe(c net.Conn) error {
+	return nil
+}

--- a/rpc/sigpipe_bsd.go
+++ b/rpc/sigpipe_bsd.go
@@ -9,7 +9,8 @@ import (
 )
 
 func DisableSigPipe(c net.Conn) error {
-	// Turn off SIGPIPE for this connection if requested.
+	// Disable SIGPIPE on this connection since we currently need to do this manually for iOS
+	// to prevent the signal from crashing iOS apps.
 	// See: https://github.com/golang/go/issues/17393
 	fd := int(reflect.ValueOf(c).Elem().FieldByName("fd").Elem().FieldByName("sysfd").Int())
 	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_NOSIGPIPE, 1)

--- a/rpc/sigpipe_bsd.go
+++ b/rpc/sigpipe_bsd.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func disableSigPipe(c net.Conn) error {
+func DisableSigPipe(c net.Conn) error {
 	// Turn off SIGPIPE for this connection if requested.
 	// See: https://github.com/golang/go/issues/17393
 	fd := int(reflect.ValueOf(c).Elem().FieldByName("fd").Elem().FieldByName("sysfd").Int())

--- a/rpc/sigpipe_bsd.go
+++ b/rpc/sigpipe_bsd.go
@@ -1,0 +1,16 @@
+//+build darwin
+
+package rpc
+
+import (
+	"net"
+	"reflect"
+	"syscall"
+)
+
+func disableSigPipe(c net.Conn) error {
+	// Turn off SIGPIPE for this connection if requested.
+	// See: https://github.com/golang/go/issues/17393
+	fd := int(reflect.ValueOf(c).Elem().FieldByName("fd").Elem().FieldByName("sysfd").Int())
+	return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_NOSIGPIPE, 1)
+}


### PR DESCRIPTION
The point of this patch is to address the iOS app force closing when foregrounded after being in the background for awhile. See more info here:

https://github.com/golang/go/issues/17393

We add an option to disable `SIGPIPE` on Darwin builds on new connections using the transports provided by this library (note only the TLS transport really matters in production). Since Linux and Windows don't have this option, it is off for those builds. 