### PR TITLE
add random backoff for reconnect

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -271,6 +271,9 @@ type Connection struct {
 	reconnectErrPtr   *error             // Filled in with fatal reconnect err (if any) before reconnectChan is closed
 	cancelFunc        context.CancelFunc // used to cancel the reconnect loop
 	reconnectedBefore bool
+
+	initialReconnectBackoffWindow time.Duration
+	randomTimer                   CancellableRandomTimer
 }
 
 // This struct contains all the connection parameters that are optional. The
@@ -288,6 +291,10 @@ type ConnectionOpts struct {
 	WrapErrorFunc    WrapErrorFunc
 	ReconnectBackoff func() backoff.BackOff
 	CommandBackoff   func() backoff.BackOff
+	// InitialReconnectBackoffWindow, if non zero, causes a random backoff
+	// before reconnecting. The random backoff timer is fast-forward-able by
+	// passing in a WithFireNow(ctx) into a RPC call.
+	InitialReconnectBackoffWindow time.Duration
 }
 
 // NewTLSConnection returns a connection that tries to connect to the
@@ -365,13 +372,14 @@ func newConnectionWithTransportAndProtocols(handler ConnectionHandler,
 	connectionPrefix := fmt.Sprintf("CONN %s %x", handler.HandlerName(),
 		randBytes)
 	connection := &Connection{
-		handler:          handler,
-		transport:        transport,
-		errorUnwrapper:   errorUnwrapper,
-		reconnectBackoff: reconnectBackoff,
-		doCommandBackoff: commandBackoff,
-		wef:              opts.WrapErrorFunc,
-		tagsFunc:         opts.TagsFunc,
+		handler:                       handler,
+		transport:                     transport,
+		errorUnwrapper:                errorUnwrapper,
+		reconnectBackoff:              reconnectBackoff,
+		doCommandBackoff:              commandBackoff,
+		initialReconnectBackoffWindow: opts.InitialReconnectBackoffWindow,
+		wef:      opts.WrapErrorFunc,
+		tagsFunc: opts.TagsFunc,
 		log: connectionLog{
 			LogOutput: log,
 			logPrefix: connectionPrefix,
@@ -537,6 +545,10 @@ func (c *Connection) doReconnect(ctx context.Context, disconnectStatus Disconnec
 	reconnectChan chan struct{}, reconnectErrPtr *error) {
 	// inform the handler of our disconnected state
 	c.handler.OnDisconnected(ctx, disconnectStatus)
+	if c.initialReconnectBackoffWindow != 0 {
+		c.randomTimer.Start(c.initialReconnectBackoffWindow)
+		c.randomTimer.Wait()
+	}
 	err := backoff.RetryNotify(func() error {
 		// try to connect
 		err := c.connect(ctx)
@@ -609,6 +621,9 @@ var _ GenericClient = connectionClient{}
 
 func (c connectionClient) Call(ctx context.Context, s string, args interface{}, res interface{}) error {
 	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {
+		if isWithFireNow(ctx) || c.conn.initialReconnectBackoffWindow != 0 {
+			c.conn.randomTimer.FireNow()
+		}
 		return rawClient.Call(ctx, s, args, res)
 	})
 }

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -623,7 +623,7 @@ type connectionClient struct {
 var _ GenericClient = connectionClient{}
 
 func (c connectionClient) Call(ctx context.Context, s string, args interface{}, res interface{}) error {
-	if isWithFireNow(ctx) || c.conn.initialReconnectBackoffWindow != 0 {
+	if c.conn.initialReconnectBackoffWindow != 0 && isWithFireNow(ctx) {
 		c.conn.randomTimer.FireNow()
 	}
 	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {

--- a/rpc/reconnect_backoff.go
+++ b/rpc/reconnect_backoff.go
@@ -1,0 +1,136 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package rpc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"sync"
+	"time"
+)
+
+// fireOnce is a construct to synchronize different go routines. Specifically,
+// one routine can use wait() to wait on a signal, and another routine can call
+// fire() to wake up the first routine. Only the first call to fire() is
+// effective, and multiple calls to fire() doesn't panic.
+//
+// A zero value fireOnce is valid, and no-op for both fire() and wait(). Use
+// newFireOnce() to make one that's fire-able.
+//
+// This is to replace the use case where a channel may be used to sychronize
+// different go routines, and one routine waits on a channel read while another
+// closes the channel to signal the first routine. fireOnce addresses the issue
+// where second call to close the channel can panic.
+type fireOnce struct {
+	ch   chan struct{}
+	once *sync.Once
+}
+
+func newFireOnce() fireOnce {
+	return fireOnce{
+		ch:   make(chan struct{}),
+		once: &sync.Once{},
+	}
+}
+
+func (o fireOnce) fire() {
+	if o.once == nil || o.ch == nil {
+		return
+	}
+	o.once.Do(func() { close(o.ch) })
+}
+
+func (o fireOnce) wait() {
+	if o.ch == nil {
+		return
+	}
+	<-o.ch
+}
+
+// CancellableRandomTimer can be used to wait on a random backoff timer. A
+// pointer to a zero value of CancellableRandomTimer if usable.
+type CancellableRandomTimer struct {
+	mu sync.Mutex
+	// A *time.Timer is not enough here since we need to be able to cancel the
+	// timer and fire the signal (as opposed to the Stop() method on time.Timer
+	// which stops the timer and prevents the signal from being fired) when
+	// switching out timers.
+	fo fireOnce
+}
+
+func (b *CancellableRandomTimer) swap(newFo fireOnce) (oldFo fireOnce) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.fo, oldFo = newFo, b.fo
+	return oldFo
+}
+
+func (b *CancellableRandomTimer) get() fireOnce {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.fo
+}
+
+// Start starts a random backoff timer. The timer is fast-forward-able with
+// b.FireNow(). Use b.Wait() to wait for the timer.
+//
+// It's OK to call b.Start() multiple times. It essentially resets the timer to
+// a new value, i.e., any pending b.Wait() waits until the last effective timer
+// completes.
+func (b *CancellableRandomTimer) Start(maxWait time.Duration) {
+	f := newFireOnce()
+	b.swap(f).fire()
+
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		panic(err)
+	}
+	waitDur := time.Duration(
+		int64(binary.LittleEndian.Uint64(buf[:])) % int64(maxWait))
+
+	time.AfterFunc(waitDur, f.fire)
+}
+
+// Wait waits on any existing random timer. If there isn't a timer
+// started, Wait() returns immediately. If b.Start() is called in the middle of
+// the wait, it waits until the new timer completes (no matter it's sonner or
+// later than the old timer). If FireNow() is called, Wait() returns
+// immediately.
+func (b *CancellableRandomTimer) Wait() {
+	var oldF fireOnce
+	f := b.get()
+	for f != oldF {
+		f.wait()
+		f, oldF = b.get(), f
+	}
+}
+
+// FireNow fast-forwards any existing timer so that any Wait() calls on b wakes
+// up immediately. If no timer exists, this is a no-op.
+func (b *CancellableRandomTimer) FireNow() {
+	b.swap(fireOnce{}).fire()
+}
+
+// CtxFireNow is a context key that when set, causes a RPC client to reconnect
+// immediately if needed.
+type CtxFireNow struct{}
+
+// WithFireNow returns a context.Context with a CtxFireNow attached.
+//
+// A bit more background: when random backoff is enabled, the RPC client waits
+// on a random timer before trying to reconnect to server in event of a
+// disconnection. However, we want this to happen only if the client device is
+// idling. User of this package should use WithFireNow to amend the context
+// passed into any RPC calls that should cause a reconnect immediately. In
+// general, that's all RPC calls except those that perform ping-like functions.
+func WithFireNow(ctx context.Context) context.Context {
+	return context.WithValue(ctx, CtxFireNow{}, true)
+}
+
+func isWithFireNow(ctx context.Context) bool {
+	yes, ok := ctx.Value(CtxFireNow{}).(bool)
+	return ok && yes
+}

--- a/rpc/reconnect_backoff.go
+++ b/rpc/reconnect_backoff.go
@@ -12,16 +12,16 @@ import (
 	"time"
 )
 
-// fireOnce is a construct to synchronize different go routines. Specifically,
+// fireOnce is a construct to synchronize different goroutines. Specifically,
 // one routine can use wait() to wait on a signal, and another routine can call
 // fire() to wake up the first routine. Only the first call to fire() is
-// effective, and multiple calls to fire() doesn't panic.
+// effective, and multiple calls to fire() don't panic.
 //
 // A zero value fireOnce is valid, and no-op for both fire() and wait(). Use
 // newFireOnce() to make one that's fire-able.
 //
-// This is to replace the use case where a channel may be used to sychronize
-// different go routines, and one routine waits on a channel read while another
+// This is to replace the use case where a channel may be used to synchronize
+// different goroutines, and one routine waits on a channel read while another
 // closes the channel to signal the first routine. fireOnce addresses the issue
 // where second call to close the channel can panic.
 type fireOnce struct {
@@ -123,7 +123,7 @@ type CtxFireNow struct{}
 // A bit more background: when random backoff is enabled, the RPC client waits
 // on a random timer before trying to reconnect to server in event of a
 // disconnection. However, we want this to happen only if the client device is
-// idling. User of this package should use WithFireNow to amend the context
+// idling. Users of this package should use WithFireNow to amend the context
 // passed into any RPC calls that should cause a reconnect immediately. In
 // general, that's all RPC calls except those that perform ping-like functions.
 func WithFireNow(ctx context.Context) context.Context {


### PR DESCRIPTION
This doesn't enable the random backoff for any existing service. See the https://github.com/keybase/kbfs/pull/994 for how to enable it.

Note that somehow this only affects reconnect behavior if server is down, but not when user Wifi is down. For latter, it still tries to reconnect every 2s, which is fine I think.

cc @maxtaco @mmaxim