### PR TITLE
fix race condition around reconnectChan

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -479,14 +479,25 @@ func (c *Connection) DoCommand(ctx context.Context, name string,
 
 // Blocks until a connnection is ready for use or the context is canceled.
 func (c *Connection) waitForConnection(ctx context.Context) error {
-	if c.IsConnected() {
-		// already connected
+	reconnectChan, reconnectErrPtr, wait :=
+		func() (chan struct{}, *error, bool) {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			if c.isConnectedLocked() {
+				// already connected
+				return nil, nil, false
+			}
+			// kick-off a connection and wait for it to complete
+			// or for the caller to cancel.
+			reconnectChan, disconnectStatus, reconnectErrPtr :=
+				c.getReconnectChanLocked()
+			c.log.Debug(
+				"Connection: waitForConnection; status: %d", disconnectStatus)
+			return reconnectChan, reconnectErrPtr, true
+		}()
+	if !wait {
 		return nil
 	}
-	// kick-off a connection and wait for it to complete
-	// or for the caller to cancel.
-	reconnectChan, disconnectStatus, reconnectErrPtr := c.getReconnectChan()
-	c.log.Debug("Connection: waitForConnection; status: %d", disconnectStatus)
 	select {
 	case <-ctx.Done():
 		// caller canceled
@@ -503,12 +514,16 @@ func (c *Connection) checkForRetry(err error) bool {
 	return err == io.EOF
 }
 
+func (c *Connection) isConnectedLocked() bool {
+	return c.transport.IsConnected() && c.client != nil
+}
+
 // IsConnected returns true if the connection is connected.  The mutex
 // must not be held by the caller.
 func (c *Connection) IsConnected() bool {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
-	return c.transport.IsConnected() && c.client != nil
+	return c.isConnectedLocked()
 }
 
 // This will either kick-off a new reconnection attempt or wait for an
@@ -516,12 +531,10 @@ func (c *Connection) IsConnected() bool {
 // and whether or not a new one was created.  If a fatal error
 // happens, reconnectErrPtr will be filled in before reconnectChan is
 // closed.
-func (c *Connection) getReconnectChan() (
+func (c *Connection) getReconnectChanLocked() (
 	reconnectChan chan struct{}, disconnectStatus DisconnectStatus,
 	reconnectErrPtr *error) {
 	c.log.Debug("Connection: getReconnectChan")
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
 	if c.reconnectChan == nil {
 		var ctx context.Context
 		// for canceling the reconnect loop via Shutdown()
@@ -539,6 +552,14 @@ func (c *Connection) getReconnectChan() (
 		disconnectStatus = UsingExistingConnection
 	}
 	return c.reconnectChan, disconnectStatus, c.reconnectErrPtr
+}
+
+func (c *Connection) getReconnectChan() (
+	reconnectChan chan struct{}, disconnectStatus DisconnectStatus,
+	reconnectErrPtr *error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.getReconnectChanLocked()
 }
 
 // doReconnect attempts a reconnection.  It assumes that reconnectChan

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -485,7 +485,7 @@ func (c *Connection) waitForConnection(ctx context.Context) error {
 			defer c.mutex.Unlock()
 			if c.isConnectedLocked() {
 				// already connected
-				return nil, 0, nil, false
+				return nil, UsingExistingConnection, nil, false
 			}
 			// kick-off a connection and wait for it to complete
 			// or for the caller to cancel.


### PR DESCRIPTION
This holds the lock slightly longer in `waitForConnection`, since otherwise we could get connected before `getReconnectChan` manages to acquire the lock, and it would try to re-reconnect.

This is a quick fix. What I really want to do is convert these logics into a FSM. I think it's gonna be easier to maintain and less likely to accommodate bugs. If you guys are OK with it, I'll create a ticket for it.