### PR TITLE
one more callsite for res_init

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -199,6 +199,15 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 		}
 		baseConn, err := dialer.Dial("tcp", ct.srvAddr)
 		if err != nil {
+			// If we get a DNS error, it could be because glibc has cached an
+			// old version of /etc/resolv.conf. The res_init() libc function
+			// busts that cache and keeps us from getting stuck in a state
+			// where DNS requests keep failing even though the network is up.
+			// This is similar to what the Rust standard library does:
+			// https://github.com/rust-lang/rust/blob/028569ab1b/src/libstd/sys_common/net.rs#L186-L190
+			// Note that we still propagate the error here, and we expect
+			// callers to retry.
+			resinit.ResInitIfDNSError(err)
 			return err
 		}
 		conn = tls.Client(baseConn, config)


### PR DESCRIPTION
As a rule of thumb, we should be calling this wherever we call
DisableSigPipe().

r? @mmaxim 