### PR TITLE
make the -lresolv CGO flag Darwin-only

### DIFF
--- a/rpc/resinit/resinit_darwin.go
+++ b/rpc/resinit/resinit_darwin.go
@@ -10,6 +10,9 @@ package resinit
 // https://github.com/keybase/keybase-issues/issues/3022.
 
 // #cgo LDFLAGS: -lresolv
+// #include<sys/types.h>
+// #include<netinet/in.h>
+// #include<arpa/nameser.h>
 // #include<resolv.h>
 import "C"
 

--- a/rpc/resinit/resinit_darwin.go
+++ b/rpc/resinit/resinit_darwin.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build darwin
+
+package resinit
+
+// NOTE: The Darwin build requires -lresolv, but that option breaks FreeBSD.
+// This implementation is split out from resinit_nix.go for that reason. See
+// https://github.com/keybase/keybase-issues/issues/3022.
+
+// #cgo LDFLAGS: -lresolv
+// #include<resolv.h>
+import "C"
+
+func resInit() {
+	C.res_init()
+}

--- a/rpc/resinit/resinit_nix.go
+++ b/rpc/resinit/resinit_nix.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build !windows,!android
+// +build !windows,!android,!darwin
 
 package resinit
 
@@ -9,7 +9,6 @@ package resinit
 // which is the default for any kind of cross-compiling (e.g. GOARCH=386). In
 // that case you must set CGO_ENABLED=1 in the environment.
 
-// #cgo LDFLAGS: -lresolv
 // #include<resolv.h>
 import "C"
 

--- a/rpc/resinit/resinit_nix.go
+++ b/rpc/resinit/resinit_nix.go
@@ -9,6 +9,9 @@ package resinit
 // which is the default for any kind of cross-compiling (e.g. GOARCH=386). In
 // that case you must set CGO_ENABLED=1 in the environment.
 
+// #include<sys/types.h>
+// #include<netinet/in.h>
+// #include<arpa/nameser.h>
 // #include<resolv.h>
 import "C"
 


### PR DESCRIPTION
Will fix https://github.com/keybase/keybase-issues/issues/3022, after this gets vendored into client. https://github.com/keybase/client/pull/7876 is a passing CI run with these changes.