### PR TITLE
fix for macos in kbfsdocker

### DIFF
--- a/rpc/resinit/resinit_linux.go
+++ b/rpc/resinit/resinit_linux.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build linux,!android
+// +build linux,!android,!noresinit
 
 package resinit
 

--- a/rpc/resinit/resinit_other.go
+++ b/rpc/resinit/resinit_other.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Keybase, Inc. All rights reserved. Use of
 // this source code is governed by the included BSD license.
 
-// +build !linux android
+// +build !linux android noresinit
 
 package resinit
 


### PR DESCRIPTION
After this (and some other PRs) the cgo resinit stuff not happen on kbfsdocker any more.