### PR TITLE
add proritized round robin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 go:
   - 1.7
   - 1.8
+  - 1.9.2
 script: go test -v -race ./...

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -201,7 +201,7 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			config = &tls.Config{ServerName: host}
 		}
 
-		ct.log.Debug("dialing %s", addr)
+		ct.log.Debug("Dialing %s", addr)
 		// connect
 		dialer := net.Dialer{
 			KeepAlive: 10 * time.Second,

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -1,3 +1,6 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
 package rpc
 
 import (
@@ -150,7 +153,7 @@ type ConnectionHandler interface {
 // uses TLS+rpc.
 type ConnectionTransportTLS struct {
 	rootCerts []byte
-	srvAddr   string
+	srvRemote Remote
 	tlsConfig *tls.Config
 
 	// Protects everything below.
@@ -160,6 +163,7 @@ type ConnectionTransportTLS struct {
 	conn            net.Conn
 	logFactory      LogFactory
 	wef             WrapErrorFunc
+	log             connectionLog
 }
 
 // Test that ConnectionTransportTLS fully implements the ConnectionTransport interface.
@@ -170,8 +174,9 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 	Transporter, error) {
 	var conn net.Conn
 	err := runUnlessCanceled(ctx, func() error {
+		addr := ct.srvRemote.GetAddress()
 		config := ct.tlsConfig
-		host, _, err := net.SplitHostPort(ct.srvAddr)
+		host, _, err := net.SplitHostPort(addr)
 		if err != nil {
 			return err
 		}
@@ -196,11 +201,12 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			config = &tls.Config{ServerName: host}
 		}
 
+		ct.log.Debug("dialing %s", addr)
 		// connect
 		dialer := net.Dialer{
 			KeepAlive: 10 * time.Second,
 		}
-		baseConn, err := dialer.Dial("tcp", ct.srvAddr)
+		baseConn, err := dialer.Dial("tcp", addr)
 		if err != nil {
 			// If we get a DNS error, it could be because glibc has cached an
 			// old version of /etc/resolv.conf. The res_init() libc function
@@ -249,6 +255,7 @@ func (ct *ConnectionTransportTLS) Finalize() {
 	defer ct.mutex.Unlock()
 	ct.transport = ct.stagedTransport
 	ct.stagedTransport = nil
+	ct.srvRemote.Reset()
 }
 
 // Close is an implementation of the ConnectionTransport interface.
@@ -325,7 +332,7 @@ type ConnectionOpts struct {
 // NewTLSConnection returns a connection that tries to connect to the
 // given server address with TLS.
 func NewTLSConnection(
-	srvAddr string,
+	srvRemote Remote,
 	rootCerts []byte,
 	errorUnwrapper ErrorUnwrapper,
 	handler ConnectionHandler,
@@ -335,9 +342,13 @@ func NewTLSConnection(
 ) *Connection {
 	transport := &ConnectionTransportTLS{
 		rootCerts:  rootCerts,
-		srvAddr:    srvAddr,
+		srvRemote:  srvRemote,
 		logFactory: logFactory,
 		wef:        opts.WrapErrorFunc,
+		log: connectionLog{
+			LogOutput: logOutput,
+			logPrefix: "CONNTSPT",
+		},
 	}
 	return newConnectionWithTransportAndProtocols(handler, transport, errorUnwrapper, logOutput, opts)
 }
@@ -345,7 +356,7 @@ func NewTLSConnection(
 // NewTLSConnectionWithTLSConfig allows you to specify a RootCA pool and also
 // a serverName (if wanted) via the full Go TLS config object.
 func NewTLSConnectionWithTLSConfig(
-	srvAddr string,
+	srvRemote Remote,
 	tlsConfig *tls.Config,
 	errorUnwrapper ErrorUnwrapper,
 	handler ConnectionHandler,
@@ -354,10 +365,14 @@ func NewTLSConnectionWithTLSConfig(
 	opts ConnectionOpts,
 ) *Connection {
 	transport := &ConnectionTransportTLS{
-		srvAddr:    srvAddr,
+		srvRemote:  srvRemote,
 		tlsConfig:  copyTLSConfig(tlsConfig),
 		logFactory: logFactory,
 		wef:        opts.WrapErrorFunc,
+		log: connectionLog{
+			LogOutput: logOutput,
+			logPrefix: "CONNTSPT",
+		},
 	}
 	return newConnectionWithTransportAndProtocols(handler, transport, errorUnwrapper, logOutput, opts)
 }

--- a/rpc/remote.go
+++ b/rpc/remote.go
@@ -15,7 +15,7 @@ import (
 type Remote interface {
 	// GetAddress gets an address of the Remote to connect to.
 	GetAddress() string
-	// Peek returns an address of the Remote to connect to without chaning the
+	// Peek returns an address of the Remote to connect to without changing the
 	// internal state. The returned address is what GetAddress() would return
 	// if called.
 	Peek() string
@@ -62,12 +62,12 @@ type prioritizedRoundRobinRemote struct {
 // NewPrioritizedRoundRobinRemote creates a new Remote that include
 // prioritized remote groups. Each call to GetAddress() will round-robin by
 // random order within the first group. If we run out of address within the
-// first group, fallback to second group and do the samething, until we've
+// first group, fallback to second group and do the same thing, until we've
 // iterated all groups where we'll start over from first group.
 //
 // Any successful connecting attempt should result in a call to Reset(). This
-// is generatlly handled by the rpc package itself and shouldn't be worried by
-// the user of rpc package unless noted otherwise.
+// is generally handled by the rpc package itself and shouldn't be worried
+// about by the user of rpc package unless noted otherwise.
 func NewPrioritizedRoundRobinRemote(addressGroups [][]string) (Remote, error) {
 	// filter out empty ones
 	cleaned := make([][]string, 0, len(addressGroups))
@@ -117,7 +117,9 @@ func (r *prioritizedRoundRobinRemote) Reset() {
 // GetAddress implements the Remote interface.
 func (r *prioritizedRoundRobinRemote) GetAddress() string {
 	r.lock.Lock()
-	defer r.lock.Unlock() // If we have run out of addresses, reset to include all addresses and
+	defer r.lock.Unlock()
+
+	// If we have run out of addresses, reset to include all addresses and
 	// start over on next call.
 	if len(r.toIterate) == 0 {
 		r.resetLocked()

--- a/rpc/remote.go
+++ b/rpc/remote.go
@@ -1,0 +1,170 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package rpc
+
+import (
+	"errors"
+	"math/rand"
+	"strings"
+	"sync"
+)
+
+// Remote defines an address or a group of addresses that all point to a remote
+// that we can connect to.
+type Remote interface {
+	// GetAddress gets an address of the Remote to connect to.
+	GetAddress() string
+	// Peek returns an address of the Remote to connect to without chaning the
+	// internal state. The returned address is what GetAddress() would return
+	// if called.
+	Peek() string
+	// Reset resets the internal counter so that next call to GetAddress()
+	// returns an address as if it were called the first time.
+	Reset()
+	// String returns a string that represents all addresses in Remote and can
+	// be used to construct a Remote that behaves the same way.
+	String() string
+}
+
+type fixedRemote string
+
+// NewFixedRemote returns a remote that always uses remoteAddr.
+func NewFixedRemote(remoteAddr string) Remote {
+	return fixedRemote(remoteAddr)
+}
+
+// GetAddress implements the Remote interface.
+func (r fixedRemote) GetAddress() string {
+	return string(r)
+}
+
+// Peek implements the Remote interface.
+func (r fixedRemote) Peek() string {
+	return string(r)
+}
+
+// Reset implements the Remote interface.
+func (r fixedRemote) Reset() {}
+
+// String implements the Remote interface.
+func (r fixedRemote) String() string {
+	return string(r)
+}
+
+type prioritizedRoundRobinRemote struct {
+	addresses [][]string
+
+	lock      sync.Mutex
+	toIterate [][]string
+}
+
+// NewPrioritizedRoundRobinRemote creates a new Remote that include
+// prioritized remote groups. Each call to GetAddress() will round-robin by
+// random order within the first group. If we run out of address within the
+// first group, fallback to second group and do the samething, until we've
+// iterated all groups where we'll start over from first group.
+//
+// Any successful connecting attempt should result in a call to Reset(). This
+// is generatlly handled by the rpc package itself and shouldn't be worried by
+// the user of rpc package unless noted otherwise.
+func NewPrioritizedRoundRobinRemote(addressGroups [][]string) (Remote, error) {
+	// filter out empty ones
+	cleaned := make([][]string, 0, len(addressGroups))
+	for _, group := range addressGroups {
+		cleanedGroup := make([]string, 0, len(group))
+		for _, addr := range group {
+			addr := strings.ToLower(strings.TrimSpace(addr))
+			if len(addr) > 0 {
+				cleanedGroup = append(cleanedGroup, addr)
+			}
+		}
+		if len(cleanedGroup) > 0 {
+			cleaned = append(cleaned, cleanedGroup)
+		}
+	}
+
+	if len(cleaned) == 0 {
+		return nil, errors.New("addressGroups has no address")
+	}
+
+	r := &prioritizedRoundRobinRemote{
+		addresses: cleaned,
+	}
+	r.resetLocked()
+	return r, nil
+}
+
+func (r *prioritizedRoundRobinRemote) resetLocked() {
+	r.toIterate = make([][]string, 0, len(r.addresses))
+	for _, group := range r.addresses {
+		groupCopied := make([]string, 0, len(group))
+		for _, i := range rand.Perm(len(group)) {
+			groupCopied = append(groupCopied, group[i])
+		}
+		r.toIterate = append(r.toIterate, groupCopied)
+	}
+}
+
+// Reset implements the Remote interface.
+func (r *prioritizedRoundRobinRemote) Reset() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.resetLocked()
+}
+
+// GetAddress implements the Remote interface.
+func (r *prioritizedRoundRobinRemote) GetAddress() string {
+	r.lock.Lock()
+	defer r.lock.Unlock() // If we have run out of addresses, reset to include all addresses and
+	// start over on next call.
+	if len(r.toIterate) == 0 {
+		r.resetLocked()
+	}
+
+	addr := r.toIterate[0][0]
+
+	// Prune one address. Also prune the address group if it's empty.
+	r.toIterate[0] = r.toIterate[0][1:]
+	for len(r.toIterate) != 0 && len(r.toIterate[0]) == 0 {
+		r.toIterate = r.toIterate[1:]
+	}
+
+	return addr
+}
+
+// Peek implements the Remote interface.
+func (r *prioritizedRoundRobinRemote) Peek() string {
+	// If we have run out of addresses, reset to include all addresses and
+	// start over on next call.
+	if len(r.toIterate) == 0 {
+		r.resetLocked()
+	}
+
+	return r.toIterate[0][0]
+}
+
+func (r *prioritizedRoundRobinRemote) String() string {
+	addressGroups := make([]string, 0, len(r.addresses))
+	for _, group := range r.addresses {
+		addressGroups = append(addressGroups, strings.Join(group, ","))
+	}
+	return strings.Join(addressGroups, ";")
+}
+
+// ParsePrioritizedRoundRobinRemote parses a string into a prioritized
+// round robin Remote. See doc for NewPrioritizedRoundRobinRemote for details
+// on the returned Remote.
+//
+// Example:
+//   "example0.com,example1.com;example0.net,example1.net" produces a
+//   prioritized round robin remote with two groups, first .com then .net.
+func ParsePrioritizedRoundRobinRemote(str string) (Remote, error) {
+	groups := strings.Split(str, ";")
+	addressGroups := make([][]string, 0, len(groups))
+	for _, group := range groups {
+		addressGroups = append(addressGroups, strings.Split(group, ","))
+	}
+	return NewPrioritizedRoundRobinRemote(addressGroups)
+}

--- a/rpc/remote_test.go
+++ b/rpc/remote_test.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrioritizedRoundRobinRemote(t *testing.T) {
+	_, err := ParsePrioritizedRoundRobinRemote(";,,;")
+	require.Error(t, err)
+
+	r, err := NewPrioritizedRoundRobinRemote([][]string{
+		[]string{}, // should be ignored
+		[]string{"a0", "a1", "a2", "a3"},
+		[]string{"b0", "b1"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a0,a1,a2,a3;b0,b1", r.String())
+
+	_, err = NewPrioritizedRoundRobinRemote(nil)
+	require.Error(t, err)
+	_, err = NewPrioritizedRoundRobinRemote([][]string{[]string{}, []string{}})
+	require.Error(t, err)
+
+	r, err = ParsePrioritizedRoundRobinRemote(`
+	;;
+	a0,a1,a2,a3;
+	;;b0,
+	b1;
+	`)
+	require.NoError(t, err)
+
+	getAndConfirmA := func() {
+		seen := make(map[string]bool)
+		for i := 0; i < 4; i++ {
+			seen[r.GetAddress()] = true
+		}
+
+		require.True(t, seen["a0"])
+		require.True(t, seen["a1"])
+		require.True(t, seen["a2"])
+		require.True(t, seen["a3"])
+	}
+
+	getAndConfirmB := func() {
+		seen := make(map[string]bool)
+		for i := 0; i < 2; i++ {
+			seen[r.GetAddress()] = true
+		}
+
+		require.True(t, seen["b0"])
+		require.True(t, seen["b1"])
+	}
+
+	getAndConfirmA()
+	getAndConfirmB()
+	getAndConfirmA()
+	r.Reset()
+	getAndConfirmA()
+	getAndConfirmB()
+}


### PR DESCRIPTION
This is so we could do:

```
Group 1: mdserver-0.kbfs.keybaseapi.com, mdserver-1.kbfs.keybaseapi.com
Group 2: mdserver-0.kbfs.keybase.io, mdserver-1.kbfs.keybase.io
Group 3: mdserver.kbfs.keybase.io
```

Where we round-robin within group 1 and never hit group 2 or 3 as long as group works. "works" is defined as TLS handshake success plus the authentication (i.e. GetChallenge, etc.) success.