### PR TITLE
add logrus support

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -333,6 +333,8 @@ type ConnectionOpts struct {
 	DialerTimeout time.Duration
 }
 
+// NewTLSConnectionWithLogrus is like NewTLSConnection, but with a logrus
+// logger.
 func NewTLSConnectionWithLogrus(
 	srvRemote Remote,
 	rootCerts []byte,
@@ -343,11 +345,12 @@ func NewTLSConnectionWithLogrus(
 	opts ConnectionOpts,
 ) *Connection {
 	transport := &ConnectionTransportTLS{
-		rootCerts:  rootCerts,
-		srvRemote:  srvRemote,
-		logFactory: logFactory,
-		wef:        opts.WrapErrorFunc,
-		log:        newConnectionLogLogrus(logrusLogger, "conn_tspt"),
+		rootCerts:     rootCerts,
+		srvRemote:     srvRemote,
+		logFactory:    logFactory,
+		wef:           opts.WrapErrorFunc,
+		dialerTimeout: opts.DialerTimeout,
+		log:           newConnectionLogLogrus(logrusLogger, "conn_tspt"),
 	}
 	connLog := newConnectionLogLogrus(logrusLogger, "conn")
 	return newConnectionWithTransportAndProtocolsWithLog(
@@ -362,15 +365,16 @@ func NewTLSConnection(
 	errorUnwrapper ErrorUnwrapper,
 	handler ConnectionHandler,
 	logFactory LogFactory,
-	logOutput LogOutput,
+	logOutput LogOutputWithDepthAdder,
 	opts ConnectionOpts,
 ) *Connection {
 	transport := &ConnectionTransportTLS{
-		rootCerts:  rootCerts,
-		srvRemote:  srvRemote,
-		logFactory: logFactory,
-		wef:        opts.WrapErrorFunc,
-		log:        newConnectionLogUnstructured(logOutput, "CONNTSPT"),
+		rootCerts:     rootCerts,
+		srvRemote:     srvRemote,
+		logFactory:    logFactory,
+		wef:           opts.WrapErrorFunc,
+		dialerTimeout: opts.DialerTimeout,
+		log:           newConnectionLogUnstructured(logOutput, "CONNTSPT"),
 	}
 	return newConnectionWithTransportAndProtocols(handler, transport, errorUnwrapper, logOutput, opts)
 }
@@ -383,7 +387,7 @@ func NewTLSConnectionWithTLSConfig(
 	errorUnwrapper ErrorUnwrapper,
 	handler ConnectionHandler,
 	logFactory LogFactory,
-	logOutput LogOutput,
+	logOutput LogOutputWithDepthAdder,
 	opts ConnectionOpts,
 ) *Connection {
 	transport := &ConnectionTransportTLS{
@@ -403,7 +407,7 @@ func NewConnectionWithTransport(
 	handler ConnectionHandler,
 	transport ConnectionTransport,
 	errorUnwrapper ErrorUnwrapper,
-	logOutput LogOutput,
+	logOutput LogOutputWithDepthAdder,
 	opts ConnectionOpts,
 ) *Connection {
 	return newConnectionWithTransportAndProtocols(handler, transport, errorUnwrapper, logOutput, opts)
@@ -449,7 +453,7 @@ func newConnectionWithTransportAndProtocolsWithLog(handler ConnectionHandler,
 
 func newConnectionWithTransportAndProtocols(handler ConnectionHandler,
 	transport ConnectionTransport, errorUnwrapper ErrorUnwrapper,
-	log LogOutput, opts ConnectionOpts) *Connection {
+	log LogOutputWithDepthAdder, opts ConnectionOpts) *Connection {
 	return newConnectionWithTransportAndProtocolsWithLog(
 		handler, transport, errorUnwrapper,
 		newConnectionLogUnstructured(log, "CONN "+handler.HandlerName()), opts)

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -202,7 +202,7 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			config = &tls.Config{ServerName: host}
 		}
 
-		ct.log.Debug("%s %s",
+		ct.log.Info("%s %s",
 			logField{key: msgKey, value: "Dialing"},
 			logField{key: "remote-addr", value: addr})
 		// connect
@@ -223,14 +223,14 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			resinit.ResInitIfDNSError(err)
 			return err
 		}
-		ct.log.Debug("baseConn: %s; Calling %s",
+		ct.log.Info("baseConn: %s; Calling %s",
 			logField{key: "local-addr", value: baseConn.LocalAddr()},
 			logField{key: msgKey, value: "Handshake"})
 		conn = tls.Client(baseConn, config)
 		if err := conn.(*tls.Conn).Handshake(); err != nil {
 			return err
 		}
-		ct.log.Debug("%s", logField{key: msgKey, value: "Handshaken"})
+		ct.log.Info("%s", logField{key: msgKey, value: "Handshaken"})
 
 		// Disable SIGPIPE on platforms that require it (Darwin). See sigpipe_bsd.go.
 		return DisableSigPipe(baseConn)
@@ -457,7 +457,7 @@ func newConnectionWithTransportAndProtocols(handler ConnectionHandler,
 
 // connect performs the actual connect() and rpc setup.
 func (c *Connection) connect(ctx context.Context) error {
-	c.log.Debug("Connection: %s",
+	c.log.Info("Connection: %s",
 		logField{key: msgKey, value: "dialing transport"})
 
 	// connect
@@ -494,7 +494,7 @@ func (c *Connection) connect(ctx context.Context) error {
 	c.server = server
 	c.transport.Finalize()
 
-	c.log.Debug("Connection: %s", logField{key: msgKey, value: "connected"})
+	c.log.Info("Connection: %s", logField{key: msgKey, value: "connected"})
 	return nil
 }
 
@@ -564,7 +564,7 @@ func (c *Connection) waitForConnection(
 	if !wait {
 		return nil
 	}
-	c.log.Debug("Connection: %s; status: %d",
+	c.log.Info("Connection: %s; status: %d",
 		logField{key: msgKey, value: "waitForConnection"},
 		logField{key: "disconnectStatus", value: disconnectStatus})
 	select {
@@ -607,7 +607,7 @@ func (c *Connection) IsConnected() bool {
 func (c *Connection) getReconnectChanLocked() (
 	reconnectChan chan struct{}, disconnectStatus DisconnectStatus,
 	reconnectErrPtr *error) {
-	c.log.Debug("Connection: %s",
+	c.log.Info("Connection: %s",
 		logField{key: msgKey, value: "getReconnectChan"})
 	if c.reconnectChan == nil {
 		var ctx context.Context
@@ -646,11 +646,11 @@ func (c *Connection) doReconnect(ctx context.Context, disconnectStatus Disconnec
 	if c.initialReconnectBackoffWindow != nil &&
 		disconnectStatus == StartingNonFirstConnection {
 		waitDur := c.randomTimer.Start(c.initialReconnectBackoffWindow())
-		c.log.Debug("starting random %s: %s",
+		c.log.Info("starting random %s: %s",
 			logField{key: msgKey, value: "backoff"},
 			logField{key: "duration", value: waitDur})
 		c.randomTimer.Wait()
-		c.log.Debug("%s!", logField{key: msgKey, value: "backoff done"})
+		c.log.Info("%s!", logField{key: msgKey, value: "backoff done"})
 	}
 	err := backoff.RetryNotify(func() error {
 		// try to connect

--- a/rpc/connection_log.go
+++ b/rpc/connection_log.go
@@ -39,11 +39,11 @@ type connectionLogUnstructured struct {
 }
 
 func newConnectionLogUnstructured(
-	logOutput LogOutput, prefix string) *connectionLogUnstructured {
+	logOutput LogOutputWithDepthAdder, prefix string) *connectionLogUnstructured {
 	randBytes := make([]byte, 4)
 	rand.Read(randBytes)
 	return &connectionLogUnstructured{
-		LogOutput: logOutput,
+		LogOutput: logOutput.CloneWithAddedDepth(1),
 		logPrefix: strings.Join(
 			[]string{prefix, hex.EncodeToString(randBytes)}, " "),
 	}

--- a/rpc/connection_log.go
+++ b/rpc/connection_log.go
@@ -1,0 +1,123 @@
+// Copyright 2018 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package rpc
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"runtime"
+)
+
+type logField struct {
+	key   string
+	value interface{}
+}
+
+// Format implements the fmt.Formatter interface, to make the structured
+// logField compatible with format-based non-structured loggers.
+func (f logField) Format(s fmt.State, verb rune) {
+	fmt.Fprintf(s, "%"+string(verb), f.value)
+}
+
+// connectionLog defines an interface used by connection.go for logging. An
+// implementation typically only uses either of `msg` and `format` field,
+// depending on if the logger is structured or not.
+type connectionLog interface {
+	Warning(msg string, format string, fields ...logField)
+	Debug(msg string, format string, fields ...logField)
+	Info(msg string, format string, fields ...logField)
+}
+
+type connectionLogUnstructured struct {
+	LogOutput
+	logPrefix string
+}
+
+func (l *connectionLogUnstructured) format(f string, lf ...logField) string {
+	fields := make([]interface{}, 0, len(lf))
+	for _, lf := range lf {
+		fields = append(fields, lf)
+	}
+	return fmt.Sprintf(f, fields...)
+}
+
+func (l *connectionLogUnstructured) Warning(
+	msg string, format string, fields ...logField) {
+	l.LogOutput.Warning("(%s) %s", l.logPrefix, l.format(format, fields...))
+}
+
+func (l *connectionLogUnstructured) Debug(
+	msg string, format string, fields ...logField) {
+	l.LogOutput.Debug("(%s) %s", l.logPrefix, l.format(format, fields...))
+}
+
+func (l *connectionLogUnstructured) Info(
+	msg string, format string, fields ...logField) {
+	l.LogOutput.Info("(%s) %s", l.logPrefix, l.format(format, fields...))
+}
+
+// LogrusEntry and LogrusLogger define methods we need from logrus to avoid
+// pulling logrus as dependency.
+type LogrusEntry interface {
+	Debug(args ...interface{})
+	Info(args ...interface{})
+	Warning(args ...interface{})
+}
+
+// LogrusLogger maps to *logrus.Logger, but will need an adapter that convers
+// map[string]interface{} to logrus.Fields, and adapt logrus.Entry to
+// LogrusEntry.
+type LogrusLogger interface {
+	WithFields(map[string]interface{}) LogrusEntry
+}
+
+type connectionLogLogrus struct {
+	log LogrusLogger
+
+	section string
+}
+
+func newConnectionLogLogrus(
+	log LogrusLogger, section string) *connectionLogLogrus {
+	randBytes := make([]byte, 4)
+	rand.Read(randBytes)
+	return &connectionLogLogrus{
+		log:     log,
+		section: section + "-" + hex.EncodeToString(randBytes),
+	}
+}
+
+func (l *connectionLogLogrus) logSkip(fields ...logField) LogrusEntry {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		file, line = "unknown", -1
+	}
+	mFields := make(map[string]interface{})
+	for _, f := range fields {
+		mFields[f.key] = f.value
+	}
+	mFields["section"] = l.section
+	mFields["file"], mFields["line"] = file, line
+	return l.log.WithFields(mFields)
+}
+
+func (l *connectionLogLogrus) Warning(
+	msg string, format string, fields ...logField) {
+	l.logSkip(fields...).Warning(msg)
+}
+
+func (l *connectionLogLogrus) Debug(
+	msg string, format string, fields ...logField) {
+	// Nasty hack to lift Debug to Info: we can't just do Info everywhere in
+	// this package since they'll leak to CLI in keybase/client. We also can't
+	// just turn on Debug logging on server-side. Since logrus loggers are only
+	// used by server side, we simply override Debug with Info here.
+	l.logSkip(fields...).Info(msg)
+}
+
+func (l *connectionLogLogrus) Info(
+	msg string, format string, fields ...logField) {
+	l.logSkip(fields...).Info(msg)
+}

--- a/rpc/connection_test_util.go
+++ b/rpc/connection_test_util.go
@@ -132,11 +132,12 @@ func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
 	t.t.Logf(fmts, args...)
 }
 
-func (t testLogOutput) Info(fmt string, args ...interface{})    { t.log("I", fmt, args) }
-func (t testLogOutput) Error(fmt string, args ...interface{})   { t.log("E", fmt, args) }
-func (t testLogOutput) Debug(fmt string, args ...interface{})   { t.log("D", fmt, args) }
-func (t testLogOutput) Warning(fmt string, args ...interface{}) { t.log("W", fmt, args) }
-func (t testLogOutput) Profile(fmt string, args ...interface{}) { t.log("P", fmt, args) }
+func (t testLogOutput) Info(fmt string, args ...interface{})                  { t.log("I", fmt, args) }
+func (t testLogOutput) Error(fmt string, args ...interface{})                 { t.log("E", fmt, args) }
+func (t testLogOutput) Debug(fmt string, args ...interface{})                 { t.log("D", fmt, args) }
+func (t testLogOutput) Warning(fmt string, args ...interface{})               { t.log("W", fmt, args) }
+func (t testLogOutput) Profile(fmt string, args ...interface{})               { t.log("P", fmt, args) }
+func (t testLogOutput) CloneWithAddedDepth(depth int) LogOutputWithDepthAdder { return t }
 
 // MakeConnectionForTest returns a Connection object, and a net.Conn
 // object representing the other end of that connection.

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -43,6 +43,11 @@ type LogOutput interface {
 	Profile(s string, args ...interface{})
 }
 
+type LogOutputWithDepthAdder interface {
+	LogOutput
+	CloneWithAddedDepth(depth int) LogOutputWithDepthAdder
+}
+
 type LogOptions interface {
 	ShowAddress() bool
 	ShowArg() bool


### PR DESCRIPTION
This PR abstracts the `connectionLog` in `connection.go` into an interface, turns the original `connectionLog` into `connectionLogUnstructured`, and adds a new `connectionLogLogrus` for structured logging. Code that uses the old interface (`NewTLSConnection`) will remain logging unstructured. In addition, in the structured logger all `Debug` logs are lifted to `Info`, since we can't use `Info` for keybase/client, and structured loggers are likely only gonna be used in servers. If that assumption changes in the future we can do some more refactoring.

The logging changes here are limited to `connection.go` only. Other parts remain unchanged.

In a separate PR, `kbfs-server` will switch to structured logging for `connection.go`.