### PR TITLE
fix memory leak: make sure framedMsgpackEncoder goroutines is cleaned up

### DIFF
--- a/rpc/mem_test.go
+++ b/rpc/mem_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build memtest
+
+package rpc
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/keybase/backoff"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+type nullLogOutput struct{}
+
+func (nullLogOutput) Info(fmt string, args ...interface{})              {}
+func (nullLogOutput) Error(fmt string, args ...interface{})             {}
+func (nullLogOutput) Debug(fmt string, args ...interface{})             {}
+func (nullLogOutput) Warning(fmt string, args ...interface{})           {}
+func (nullLogOutput) Profile(fmt string, args ...interface{})           {}
+func (n nullLogOutput) CloneWithAddedDepth(int) LogOutputWithDepthAdder { return n }
+
+func startServer(t *testing.T) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", testPort))
+	require.NoError(t, err)
+	go func() {
+		for {
+			c, err := listener.Accept()
+			require.NoError(t, err)
+			xp := NewTransport(c, NewSimpleLogFactory(nullLogOutput{}, nil), nil)
+			srv := NewServer(xp, nil)
+			srv.Run()
+		}
+	}()
+}
+
+type memoryLeakTester struct {
+	numConnects int
+}
+
+// HandlerName implements the ConnectionHandler interface.
+func (memoryLeakTester) HandlerName() string {
+	return "memoryLeakTester"
+}
+
+// OnConnect implements the ConnectionHandler interface.
+func (mlt *memoryLeakTester) OnConnect(context.Context, *Connection, GenericClient, *Server) error {
+	mlt.numConnects++
+	runtime.GC()
+	if mlt.numConnects%100 == 0 {
+		for _, p := range pprof.Profiles() {
+			if p.Name() != "goroutine" {
+				continue
+			}
+			fmt.Printf("\n======== START Profile: %s ========\n\n", p.Name())
+			_ = p.WriteTo(os.Stdout, 2)
+			fmt.Printf("\n======== END   Profile: %s ========\n\n", p.Name())
+		}
+	}
+	return errors.New("nope")
+}
+
+// OnConnectError implements the ConnectionHandler interface.
+func (mlt *memoryLeakTester) OnConnectError(error, time.Duration) {
+}
+
+// OnDoCommandError implements the ConnectionHandler interace
+func (mlt *memoryLeakTester) OnDoCommandError(error, time.Duration) {
+}
+
+// OnDisconnected implements the ConnectionHandler interface.
+func (mlt *memoryLeakTester) OnDisconnected(context.Context, DisconnectStatus) {
+}
+
+func (mlt *memoryLeakTester) ShouldRetry(name string, err error) bool {
+	return true
+}
+
+func (mlt *memoryLeakTester) ShouldRetryOnConnect(err error) bool {
+	return true
+}
+
+func TestMemoryLeak(t *testing.T) {
+	output := nullLogOutput{}
+	startServer(t)
+	reconnectBackoffFn := func() backoff.BackOff {
+		return backoff.NewConstantBackOff(1 * time.Millisecond)
+	}
+	opts := ConnectionOpts{
+		WrapErrorFunc:    testWrapError,
+		TagsFunc:         testLogTags,
+		ReconnectBackoff: reconnectBackoffFn,
+	}
+	connTransport := NewConnectionTransport(&FMPURI{
+		Scheme:   "tcp",
+		HostPort: "127.0.0.1:" + strconv.Itoa(testPort),
+	}, NewSimpleLogFactory(nullLogOutput{}, nil), nil)
+	conn := NewConnectionWithTransport(&memoryLeakTester{}, connTransport, nil, output, opts)
+	conn.getReconnectChan()
+	select {}
+}

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -71,8 +71,8 @@ type transport struct {
 	protocols  *protocolHandler
 	calls      *callContainer
 	log        LogInterface
-	closeOnce  *sync.Once
-	startOnce  *sync.Once
+	closeOnce  sync.Once
+	startOnce  sync.Once
 	stopCh     chan struct{}
 
 	// Filled in right before stopCh is closed.
@@ -89,8 +89,6 @@ func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc) Transporter {
 	ret := &transport{
 		cdec:      cdec,
 		log:       log,
-		closeOnce: &sync.Once{},
-		startOnce: &sync.Once{},
 		stopCh:    make(chan struct{}),
 		protocols: newProtocolHandler(wef),
 		calls:     newCallContainer(),

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"sync"
 
 	"github.com/keybase/go-codec/codec"
 )
@@ -37,6 +38,9 @@ type Transporter interface {
 	// After done() is closed, successive calls to err return the
 	// same value.
 	err() error
+
+	// Close closes the transport and releases resources.
+	Close()
 }
 
 type connDecoder struct {
@@ -67,7 +71,8 @@ type transport struct {
 	protocols  *protocolHandler
 	calls      *callContainer
 	log        LogInterface
-	startCh    chan struct{}
+	closeOnce  *sync.Once
+	startOnce  *sync.Once
 	stopCh     chan struct{}
 
 	// Filled in right before stopCh is closed.
@@ -81,13 +86,11 @@ func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc) Transporter {
 	}
 	log := l.NewLog(cdec.RemoteAddr())
 
-	startCh := make(chan struct{}, 1)
-	startCh <- struct{}{}
-
 	ret := &transport{
 		cdec:      cdec,
 		log:       log,
-		startCh:   startCh,
+		closeOnce: &sync.Once{},
+		startOnce: &sync.Once{},
 		stopCh:    make(chan struct{}),
 		protocols: newProtocolHandler(wef),
 		calls:     newCallContainer(),
@@ -100,6 +103,23 @@ func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc) Transporter {
 	return ret
 }
 
+func (t *transport) Close() {
+	t.closeOnce.Do(func() {
+		// Since the receiver might require the transport, we have to
+		// close it before terminating our loops
+		close(t.stopCh)
+		t.dispatcher.Close()
+		<-t.receiver.Close()
+
+		// First inform the encoder that it should close
+		encoderClosed := t.enc.Close()
+		// Unblock any remaining writes
+		t.cdec.Close()
+		// Wait for the encoder to finish handling the now unblocked writes
+		<-encoderClosed
+	})
+}
+
 func (t *transport) IsConnected() bool {
 	select {
 	case <-t.stopCh:
@@ -110,17 +130,9 @@ func (t *transport) IsConnected() bool {
 }
 
 func (t *transport) receiveFrames() <-chan struct{} {
-	select {
-	case <-t.startCh:
-		// First time -- start receiving frames.
-		go func() {
-			t.receiveFramesLoop()
-		}()
-
-	default:
-		// Subsequent times -- do nothing.
-	}
-
+	t.startOnce.Do(func() {
+		go t.receiveFramesLoop()
+	})
 	return t.stopCh
 }
 
@@ -154,18 +166,7 @@ func (t *transport) receiveFramesLoop() {
 	// ordering.
 	t.stopErr = err
 
-	// Since the receiver might require the transport, we have to
-	// close it before terminating our loops
-	close(t.stopCh)
-	t.dispatcher.Close()
-	<-t.receiver.Close()
-
-	// First inform the encoder that it should close
-	encoderClosed := t.enc.Close()
-	// Unblock any remaining writes
-	t.cdec.Close()
-	// Wait for the encoder to finish handling the now unblocked writes
-	<-encoderClosed
+	t.Close()
 }
 
 func (t *transport) getDispatcher() (dispatcher, error) {


### PR DESCRIPTION
When `OnConnect` returns an error, `connect()` doesn't call `receiveFrames`, thus none of the cleanup code gets to run. So each time we dial a new connection and call `NewTransport`, a `writerLoop` goroutine gets spawned by `*framedMsgpackEncoder`. If this repeatedly happens, over time we'd have tons of those goroutines lying around. This PR adds a `Close()` method to `Transporter` and call it in `connection.go` whenever an old `Transporter` is replaced.

Also added a simple repro that keeps returning error on `OnConnect` and uses a 1ms backoff. To run it: 

```
go test -c -tags=memtest && ./rpc.test -test.run TestMemoryLeak
```

Without changes in this PR, it jumps to tens of MBs in seconds. With this PR, it climbs up from 3.xMB very slowly, about 0.1MB every couple seconds. So there might still be some leaks but should be pretty negligible I think.

User issue: https://github.com/keybase/client/issues/10172