### PR TITLE
pass the RPC SeqNumber to calling rpc.Client or receiving rpc.Server

### DIFF
--- a/rpc/call.go
+++ b/rpc/call.go
@@ -12,7 +12,7 @@ type call struct {
 	resultCh chan *rpcResponseMessage
 
 	method         string
-	seqid          seqNumber
+	seqid          SeqNumber
 	arg            interface{}
 	res            interface{}
 	errorUnwrapper ErrorUnwrapper
@@ -20,14 +20,14 @@ type call struct {
 
 type callContainer struct {
 	callsMtx sync.RWMutex
-	calls    map[seqNumber]*call
+	calls    map[SeqNumber]*call
 	seqMtx   sync.Mutex
-	seqid    seqNumber
+	seqid    SeqNumber
 }
 
 func newCallContainer() *callContainer {
 	return &callContainer{
-		calls: make(map[seqNumber]*call),
+		calls: make(map[SeqNumber]*call),
 		seqid: 0,
 	}
 }
@@ -48,7 +48,7 @@ func (cc *callContainer) NewCall(ctx context.Context, m string, arg interface{},
 	}
 }
 
-func (cc *callContainer) nextSeqid() seqNumber {
+func (cc *callContainer) nextSeqid() SeqNumber {
 	cc.seqMtx.Lock()
 	defer cc.seqMtx.Unlock()
 
@@ -64,14 +64,14 @@ func (cc *callContainer) AddCall(c *call) {
 	cc.calls[c.seqid] = c
 }
 
-func (cc *callContainer) RetrieveCall(seqid seqNumber) *call {
+func (cc *callContainer) RetrieveCall(seqid SeqNumber) *call {
 	cc.callsMtx.RLock()
 	defer cc.callsMtx.RUnlock()
 
 	return cc.calls[seqid]
 }
 
-func (cc *callContainer) RemoveCall(seqid seqNumber) {
+func (cc *callContainer) RemoveCall(seqid SeqNumber) {
 	cc.callsMtx.Lock()
 	defer cc.callsMtx.Unlock()
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -15,6 +15,10 @@ type Client struct {
 	tagsFunc       LogTagsFromContext
 }
 
+type SeqNumberReceiver interface {
+	SetSeqNumber(s SeqNumber)
+}
+
 // NewClient constructs a new client from the given RPC Transporter and the
 // ErrorUnwrapper.
 func NewClient(xp Transporter, u ErrorUnwrapper,

--- a/rpc/codec_test.go
+++ b/rpc/codec_test.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/keybase/go-codec/codec"
+	"github.com/stretchr/testify/require"
 )
 
 // This test determines the behavior of codec with respect to advancing the

--- a/rpc/dispatch.go
+++ b/rpc/dispatch.go
@@ -69,6 +69,9 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 	// Wait for result from call
 	select {
 	case res := <-c.resultCh:
+		if snr, ok := res.Res().(SeqNumberReceiver); ok {
+			snr.SetSeqNumber(c.seqid)
+		}
 		d.log.ClientReply(c.seqid, c.method, res.ResponseErr(), res.Res())
 		return res.ResponseErr()
 	case <-c.ctx.Done():

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -93,10 +93,10 @@ func NewTypeError(expected, actual interface{}) TypeError {
 }
 
 type CallNotFoundError struct {
-	seqno seqNumber
+	seqno SeqNumber
 }
 
-func newCallNotFoundError(s seqNumber) CallNotFoundError {
+func newCallNotFoundError(s SeqNumber) CallNotFoundError {
 	return CallNotFoundError{seqno: s}
 }
 
@@ -105,7 +105,7 @@ func (c CallNotFoundError) Error() string {
 }
 
 type NilResultError struct {
-	seqno seqNumber
+	seqno SeqNumber
 }
 
 func (c NilResultError) Error() string {

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -16,17 +16,17 @@ type Profiler interface {
 type LogInterface interface {
 	TransportStart()
 	TransportError(error)
-	ClientCall(seqNumber, string, interface{})
-	ServerCall(seqNumber, string, error, interface{})
-	ServerReply(seqNumber, string, error, interface{})
+	ClientCall(SeqNumber, string, interface{})
+	ServerCall(SeqNumber, string, error, interface{})
+	ServerReply(SeqNumber, string, error, interface{})
 	ClientNotify(string, interface{})
 	ServerNotifyCall(string, error, interface{})
 	ServerNotifyComplete(string, error)
-	ClientCancel(seqNumber, string, error)
-	ServerCancelCall(seqNumber, string)
-	ClientReply(seqNumber, string, error, interface{})
+	ClientCancel(SeqNumber, string, error)
+	ServerCancelCall(SeqNumber, string)
+	ClientReply(SeqNumber, string, error, interface{})
 	StartProfiler(format string, args ...interface{}) Profiler
-	UnexpectedReply(seqNumber)
+	UnexpectedReply(SeqNumber)
 	Warning(format string, args ...interface{})
 	Info(format string, args ...interface{})
 }
@@ -185,17 +185,17 @@ func (l SimpleLog) TransportError(e error) {
 }
 
 // Call
-func (s SimpleLog) ClientCall(q seqNumber, meth string, arg interface{}) {
+func (s SimpleLog) ClientCall(q SeqNumber, meth string, arg interface{}) {
 	if s.Opts.ClientTrace() {
 		s.trace("call", "arg", s.Opts.ShowArg(), q, meth, nil, arg)
 	}
 }
-func (s SimpleLog) ServerCall(q seqNumber, meth string, err error, arg interface{}) {
+func (s SimpleLog) ServerCall(q SeqNumber, meth string, err error, arg interface{}) {
 	if s.Opts.ServerTrace() {
 		s.trace("serve", "arg", s.Opts.ShowArg(), q, meth, err, arg)
 	}
 }
-func (s SimpleLog) ServerReply(q seqNumber, meth string, err error, res interface{}) {
+func (s SimpleLog) ServerReply(q SeqNumber, meth string, err error, res interface{}) {
 	if s.Opts.ServerTrace() {
 		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res)
 	}
@@ -219,24 +219,24 @@ func (s SimpleLog) ServerNotifyComplete(meth string, err error) {
 }
 
 // Cancel
-func (s SimpleLog) ClientCancel(q seqNumber, meth string, err error) {
+func (s SimpleLog) ClientCancel(q SeqNumber, meth string, err error) {
 	if s.Opts.ClientTrace() {
 		s.trace("cancel", "", false, q, meth, err, nil)
 	}
 }
-func (s SimpleLog) ServerCancelCall(q seqNumber, meth string) {
+func (s SimpleLog) ServerCancelCall(q SeqNumber, meth string) {
 	if s.Opts.ServerTrace() {
 		s.trace("serve-cancel", "", false, q, meth, nil, nil)
 	}
 }
 
-func (s SimpleLog) ClientReply(q seqNumber, meth string, err error, res interface{}) {
+func (s SimpleLog) ClientReply(q SeqNumber, meth string, err error, res interface{}) {
 	if s.Opts.ClientTrace() {
 		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res)
 	}
 }
 
-func (s SimpleLog) trace(which string, objname string, verbose bool, q seqNumber, meth string, err error, obj interface{}) {
+func (s SimpleLog) trace(which string, objname string, verbose bool, q SeqNumber, meth string, err error, obj interface{}) {
 	args := []interface{}{which, q}
 	fmts := "%s(%d):"
 	if len(meth) > 0 {
@@ -278,7 +278,7 @@ func (s SimpleLog) StartProfiler(format string, args ...interface{}) Profiler {
 	}
 }
 
-func (s SimpleLog) UnexpectedReply(seqno seqNumber) {
+func (s SimpleLog) UnexpectedReply(seqno SeqNumber) {
 	s.Out.Warning(s.msg(false, "Unexpected seqno %d in incoming reply", seqno))
 }
 

--- a/rpc/message.go
+++ b/rpc/message.go
@@ -10,7 +10,7 @@ import (
 type rpcMessage interface {
 	Type() MethodType
 	Name() string
-	SeqNo() seqNumber
+	SeqNo() SeqNumber
 	MinLength() int
 	Err() error
 	DecodeMessage(int, decoder, *protocolHandler, *callContainer) error
@@ -41,7 +41,7 @@ func (r *basicRPCData) loadContext(l int, d decoder) error {
 
 type rpcCallMessage struct {
 	basicRPCData
-	seqno seqNumber
+	seqno SeqNumber
 	name  string
 	arg   interface{}
 	err   error
@@ -72,7 +72,7 @@ func (r rpcCallMessage) Type() MethodType {
 	return MethodCall
 }
 
-func (r rpcCallMessage) SeqNo() seqNumber {
+func (r rpcCallMessage) SeqNo() SeqNumber {
 	return r.seqno
 }
 
@@ -99,7 +99,7 @@ func (r rpcResponseMessage) MinLength() int {
 }
 
 func (r *rpcResponseMessage) DecodeMessage(l int, d decoder, _ *protocolHandler, cc *callContainer) error {
-	var seqNo seqNumber
+	var seqNo SeqNumber
 	if r.err = d.Decode(&seqNo); r.err != nil {
 		return r.err
 	}
@@ -151,7 +151,7 @@ func (r rpcResponseMessage) Type() MethodType {
 	return MethodResponse
 }
 
-func (r rpcResponseMessage) SeqNo() seqNumber {
+func (r rpcResponseMessage) SeqNo() SeqNumber {
 	if r.c == nil {
 		return -1
 	}
@@ -216,7 +216,7 @@ func (r rpcNotifyMessage) Type() MethodType {
 	return MethodNotify
 }
 
-func (r rpcNotifyMessage) SeqNo() seqNumber {
+func (r rpcNotifyMessage) SeqNo() SeqNumber {
 	return -1
 }
 
@@ -233,7 +233,7 @@ func (r rpcNotifyMessage) Err() error {
 }
 
 type rpcCancelMessage struct {
-	seqno seqNumber
+	seqno SeqNumber
 	name  string
 	err   error
 }
@@ -254,7 +254,7 @@ func (r rpcCancelMessage) Type() MethodType {
 	return MethodCancel
 }
 
-func (r rpcCancelMessage) SeqNo() seqNumber {
+func (r rpcCancelMessage) SeqNo() SeqNumber {
 	return r.seqno
 }
 

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -49,7 +49,7 @@ func TestMessageDecodeValid(t *testing.T) {
 	c, ok := rpc.(*rpcCallMessage)
 	require.True(t, ok)
 	require.Equal(t, MethodCall, c.Type())
-	require.Equal(t, seqNumber(999), c.SeqNo())
+	require.Equal(t, SeqNumber(999), c.SeqNo())
 	require.Equal(t, "abc.hello", c.Name())
 	require.Equal(t, nil, c.Arg())
 }
@@ -63,7 +63,7 @@ func TestMessageDecodeValidExtraParams(t *testing.T) {
 	c, ok := rpc.(*rpcCallMessage)
 	require.True(t, ok)
 	require.Equal(t, MethodCall, c.Type())
-	require.Equal(t, seqNumber(999), c.SeqNo())
+	require.Equal(t, SeqNumber(999), c.SeqNo())
 	require.Equal(t, "abc.hello", c.Name())
 	require.Equal(t, nil, c.Arg())
 	resultTags, ok := RpcTagsFromContext(c.Context())
@@ -72,14 +72,14 @@ func TestMessageDecodeValidExtraParams(t *testing.T) {
 }
 
 func TestMessageDecodeValidResponse(t *testing.T) {
-	v := []interface{}{MethodResponse, seqNumber(0), nil, "hi"}
+	v := []interface{}{MethodResponse, SeqNumber(0), nil, "hi"}
 
 	rpc, err := runMessageTest(t, v)
 	require.Nil(t, err)
 	r, ok := rpc.(*rpcResponseMessage)
 	require.True(t, ok)
 	require.Equal(t, MethodResponse, r.Type())
-	require.Equal(t, seqNumber(0), r.SeqNo())
+	require.Equal(t, SeqNumber(0), r.SeqNo())
 	resAsString, ok := r.Res().(*string)
 	require.True(t, ok)
 	require.Equal(t, "hi", *resAsString)
@@ -87,42 +87,42 @@ func TestMessageDecodeValidResponse(t *testing.T) {
 }
 
 func TestMessageDecodeInvalidType(t *testing.T) {
-	v := []interface{}{"hello", seqNumber(0), "invalid", new(interface{})}
+	v := []interface{}{"hello", SeqNumber(0), "invalid", new(interface{})}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: -1, method: , length: 4, error: error decoding message field at position 0, error: [pos 1]: Unhandled single-byte unsigned integer value: Unrecognized descriptor byte: a5")
 }
 
 func TestMessageDecodeInvalidMethodType(t *testing.T) {
-	v := []interface{}{MethodType(999), seqNumber(0), "invalid", new(interface{})}
+	v := []interface{}{MethodType(999), SeqNumber(0), "invalid", new(interface{})}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: 999, method: , length: 4, error: invalid RPC type")
 }
 
 func TestMessageDecodeInvalidProtocol(t *testing.T) {
-	v := []interface{}{MethodCall, seqNumber(0), "nonexistent.broken", new(interface{})}
+	v := []interface{}{MethodCall, SeqNumber(0), "nonexistent.broken", new(interface{})}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: 0, method: nonexistent.broken, length: 4, error: protocol not found: nonexistent")
 }
 
 func TestMessageDecodeInvalidMethod(t *testing.T) {
-	v := []interface{}{MethodCall, seqNumber(0), "abc.invalid", new(interface{})}
+	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid", new(interface{})}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: 0, method: abc.invalid, length: 4, error: method 'invalid' not found in protocol 'abc'")
 }
 
 func TestMessageDecodeWrongMessageLength(t *testing.T) {
-	v := []interface{}{MethodCall, seqNumber(0), "abc.invalid"}
+	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid"}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: 0, method: , length: 3, error: wrong message length")
 }
 
 func TestMessageDecodeResponseNilCall(t *testing.T) {
-	v := []interface{}{MethodResponse, seqNumber(-1), 32, "hi"}
+	v := []interface{}{MethodResponse, SeqNumber(-1), 32, "hi"}
 
 	_, err := runMessageTest(t, v)
 	require.EqualError(t, err, "RPC error. type: 1, method: , length: 4, error: Call not found for sequence number -1")

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -35,7 +35,7 @@ type Protocol struct {
 
 type protocolMap map[string]Protocol
 
-type seqNumber int
+type SeqNumber int
 
 type protocolHandler struct {
 	wef       WrapErrorFunc

--- a/rpc/receiver.go
+++ b/rpc/receiver.go
@@ -3,7 +3,7 @@ package rpc
 import "golang.org/x/net/context"
 
 type task struct {
-	seqid      seqNumber
+	seqid      SeqNumber
 	cancelFunc context.CancelFunc
 }
 
@@ -25,8 +25,8 @@ type receiveHandler struct {
 
 	// Task loop channels
 	taskBeginCh  chan *task
-	taskCancelCh chan seqNumber
-	taskEndCh    chan seqNumber
+	taskCancelCh chan SeqNumber
+	taskEndCh    chan SeqNumber
 
 	log LogInterface
 }
@@ -40,8 +40,8 @@ func newReceiveHandler(enc encoder, protHandler *protocolHandler, l LogInterface
 		closedCh:    make(chan struct{}),
 
 		taskBeginCh:  make(chan *task),
-		taskCancelCh: make(chan seqNumber),
-		taskEndCh:    make(chan seqNumber),
+		taskCancelCh: make(chan SeqNumber),
+		taskEndCh:    make(chan SeqNumber),
 
 		log: l,
 	}
@@ -50,7 +50,7 @@ func newReceiveHandler(enc encoder, protHandler *protocolHandler, l LogInterface
 }
 
 func (r *receiveHandler) taskLoop() {
-	tasks := make(map[seqNumber]context.CancelFunc)
+	tasks := make(map[SeqNumber]context.CancelFunc)
 	for {
 		select {
 		case <-r.stopCh:

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -35,7 +35,7 @@ func testReceive(t *testing.T, p *Protocol, rpc rpcMessage) (receiver, chan erro
 	return r, errCh
 }
 
-func makeCall(seq seqNumber, name string, arg interface{}) *rpcCallMessage {
+func makeCall(seq SeqNumber, name string, arg interface{}) *rpcCallMessage {
 	return &rpcCallMessage{
 		seqno: seq,
 		name:  name,


### PR DESCRIPTION
- If the Arg or Res implements the `SeqNumberReceiver` interface, then we'll call `x.SetSeqNumber(n)` on it, where `x` is the Arg or Res, and `n` is the RPC `SeqNumber`.
- It's pretty easy to do this for the Res case, but for the Arg case, we have to use some type reflection system.
- This all is necessary for implementing EMOM (Encrypted Msgpack Over Msgpack)
- Should have no effect on res/args that don't implement `SeqNumberReceiver`