### PR TITLE
Work around go-codec wrapping Read errors

### DIFF
--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -12,18 +12,32 @@ type packetizer interface {
 	NextFrame() (rpcMessage, error)
 }
 
+// lastErrReader stores the last error returned by its child
+// reader. It's used by loadNextFrame below.
+type lastErrReader struct {
+	reader io.Reader
+	err    error
+}
+
+func (r *lastErrReader) Read(buf []byte) (int, error) {
+	n, err := r.reader.Read(buf)
+	r.err = err
+	return n, err
+}
+
 type packetHandler struct {
 	lengthDecoder *codec.Decoder
-	reader        io.Reader
+	reader        *lastErrReader
 	fieldDecoder  *fieldDecoder
 	protocols     *protocolHandler
 	calls         *callContainer
 }
 
 func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callContainer) *packetHandler {
+	wrappedReader := &lastErrReader{reader, nil}
 	return &packetHandler{
-		lengthDecoder: codec.NewDecoder(reader, newCodecMsgpackHandle()),
-		reader:        reader,
+		lengthDecoder: codec.NewDecoder(wrappedReader, newCodecMsgpackHandle()),
+		reader:        wrappedReader,
 		fieldDecoder:  newFieldDecoder(),
 		protocols:     protocols,
 		calls:         calls,
@@ -73,9 +87,11 @@ func (p *packetHandler) loadNextFrame() ([]byte, error) {
 	// Get the packet length
 	var l int
 	if err := p.lengthDecoder.Decode(&l); err != nil {
-		if _, ok := err.(*net.OpError); ok {
-			// If the connection is reset or has been closed on this side,
-			// return EOF
+		// If the connection is reset or has been closed on
+		// this side, return EOF. lengthDecoder wraps most
+		// errors, so we have to check p.reader.err instead of
+		// err.
+		if _, ok := p.reader.err.(*net.OpError); ok {
 			return nil, io.EOF
 		}
 		return nil, err


### PR DESCRIPTION
This fixes https://keybase.atlassian.net/browse/CORE-8323 .