### PR TITLE
Add log method for read frames

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.7
-  - 1.8
   - 1.9.2
   - 1.10.3
 script: go test -v -race ./...

--- a/rpc/connection_test_util.go
+++ b/rpc/connection_test_util.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"time"
@@ -116,28 +115,6 @@ func (eu testErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dispa
 	}
 	return appError, nil
 }
-
-// TestLogger is an interface for things, like *testing.T, that have a
-// Logf function.
-type TestLogger interface {
-	Logf(format string, args ...interface{})
-}
-
-type testLogOutput struct {
-	t TestLogger
-}
-
-func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
-	fmts = fmt.Sprintf("[%s] %s", ch, fmts)
-	t.t.Logf(fmts, args...)
-}
-
-func (t testLogOutput) Info(fmt string, args ...interface{})                  { t.log("I", fmt, args) }
-func (t testLogOutput) Error(fmt string, args ...interface{})                 { t.log("E", fmt, args) }
-func (t testLogOutput) Debug(fmt string, args ...interface{})                 { t.log("D", fmt, args) }
-func (t testLogOutput) Warning(fmt string, args ...interface{})               { t.log("W", fmt, args) }
-func (t testLogOutput) Profile(fmt string, args ...interface{})               { t.log("P", fmt, args) }
-func (t testLogOutput) CloneWithAddedDepth(depth int) LogOutputWithDepthAdder { return t }
 
 // MakeConnectionForTest returns a Connection object, and a net.Conn
 // object representing the other end of that connection.

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -125,7 +125,8 @@ func TestDispatchCancelEndToEnd(t *testing.T) {
 	dispatchConn, _ := net.Pipe()
 	enc := newFramedMsgpackEncoder(dispatchConn)
 	cc := newCallContainer()
-	d := newDispatch(enc, cc, newTestLog(t))
+	log := newTestLog(t)
+	d := newDispatch(enc, cc, log)
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dispatchTestCallWithContext(t *testing.T, ctx context.Context) (dispatcher, *callContainer, chan error) {
-	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	log := newTestLog(t)
 
 	conn1, conn2 := net.Pipe()
 	dispatchOut := newFramedMsgpackEncoder(conn1)

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 func dispatchTestCallWithContext(t *testing.T, ctx context.Context) (dispatcher, *callContainer, chan error) {
+	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+
 	conn1, conn2 := net.Pipe()
 	dispatchOut := newFramedMsgpackEncoder(conn1)
 	calls := newCallContainer()
-	pkt := newPacketHandler(conn2, createMessageTestProtocol(), calls)
+	pkt := newPacketHandler(conn2, createMessageTestProtocol(), calls, log)
 
-	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
-	d := newDispatch(dispatchOut, calls, logFactory.NewLog(nil))
+	d := newDispatch(dispatchOut, calls, log)
 
 	done := runInBg(func() error {
 		return d.Call(ctx, "abc.hello", new(interface{}), new(interface{}), nil, nil)

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -123,10 +123,9 @@ func TestDispatchCallAfterClose(t *testing.T) {
 
 func TestDispatchCancelEndToEnd(t *testing.T) {
 	dispatchConn, _ := net.Pipe()
-	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
 	enc := newFramedMsgpackEncoder(dispatchConn)
 	cc := newCallContainer()
-	d := newDispatch(enc, cc, logFactory.NewLog(nil))
+	d := newDispatch(enc, cc, newTestLog(t))
 
 	ctx1, cancel1 := context.WithCancel(context.Background())
 

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -120,7 +120,7 @@ type RPCDecodeError struct {
 }
 
 func (r RPCDecodeError) Error() string {
-	return fmt.Sprintf("RPC error. type: %d, method: %s, length: %d, error: %v", r.typ, r.name, r.len, r.err)
+	return fmt.Sprintf("RPC error. type: %s, method: %s, length: %d, error: %v", r.typ, r.name, r.len, r.err)
 }
 
 func newRPCDecodeError(t MethodType, n string, l int, e error) RPCDecodeError {

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -16,6 +16,7 @@ type Profiler interface {
 type LogInterface interface {
 	TransportStart()
 	TransportError(error)
+	// The passed-in slice should not be mutated.
 	FrameRead([]byte)
 	ClientCall(SeqNumber, string, interface{})
 	ServerCall(SeqNumber, string, error, interface{})

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -16,7 +16,7 @@ type Profiler interface {
 type LogInterface interface {
 	TransportStart()
 	TransportError(error)
-	FrameBytes([]byte)
+	FrameRead([]byte)
 	ClientCall(SeqNumber, string, interface{})
 	ServerCall(SeqNumber, string, error, interface{})
 	ServerReply(SeqNumber, string, error, interface{})
@@ -54,6 +54,7 @@ type LogOptions interface {
 	ShowArg() bool
 	ShowResult() bool
 	Profile() bool
+	FrameTrace() bool
 	ClientTrace() bool
 	ServerTrace() bool
 	TransportStart() bool
@@ -90,11 +91,13 @@ func (so SimpleLogOptions) ShowAddress() bool    { return true }
 func (so SimpleLogOptions) ShowArg() bool        { return true }
 func (so SimpleLogOptions) ShowResult() bool     { return true }
 func (so SimpleLogOptions) Profile() bool        { return true }
+func (so SimpleLogOptions) FrameTrace() bool     { return true }
 func (so SimpleLogOptions) ClientTrace() bool    { return true }
 func (so SimpleLogOptions) ServerTrace() bool    { return true }
 func (so SimpleLogOptions) TransportStart() bool { return true }
 
 type StandardLogOptions struct {
+	frameTrace     bool
 	clientTrace    bool
 	serverTrace    bool
 	profile        bool
@@ -107,22 +110,19 @@ func (s *StandardLogOptions) ShowAddress() bool    { return !s.noAddress }
 func (s *StandardLogOptions) ShowArg() bool        { return s.verboseTrace }
 func (s *StandardLogOptions) ShowResult() bool     { return s.verboseTrace }
 func (s *StandardLogOptions) Profile() bool        { return s.profile }
+func (s *StandardLogOptions) FrameTrace() bool     { return s.frameTrace }
 func (s *StandardLogOptions) ClientTrace() bool    { return s.clientTrace }
 func (s *StandardLogOptions) ServerTrace() bool    { return s.serverTrace }
 func (s *StandardLogOptions) TransportStart() bool { return s.connectionInfo }
 
 func NewStandardLogOptions(opts string, log LogOutput) LogOptions {
 	var s StandardLogOptions
-	s.clientTrace = false
-	s.serverTrace = false
-	s.profile = false
-	s.verboseTrace = false
-	s.connectionInfo = false
-	s.noAddress = false
 	for _, c := range opts {
 		switch c {
 		case 'A':
 			s.noAddress = true
+		case 'f':
+			s.frameTrace = true
 		case 'c':
 			s.clientTrace = true
 		case 's':
@@ -185,8 +185,9 @@ func (l SimpleLog) TransportError(e error) {
 	return
 }
 
-func (s SimpleLog) FrameBytes(bytes []byte) {
-	if s.Opts.ClientTrace() {
+func (s SimpleLog) FrameRead(bytes []byte) {
+	if s.Opts.FrameTrace() {
+		s.Out.Debug(s.msg(false, "Frame read: %x", bytes))
 	}
 }
 

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -16,6 +16,7 @@ type Profiler interface {
 type LogInterface interface {
 	TransportStart()
 	TransportError(error)
+	FrameBytes([]byte)
 	ClientCall(SeqNumber, string, interface{})
 	ServerCall(SeqNumber, string, error, interface{})
 	ServerReply(SeqNumber, string, error, interface{})
@@ -182,6 +183,11 @@ func (l SimpleLog) TransportError(e error) {
 		l.Out.Debug(l.msg(true, "EOF"))
 	}
 	return
+}
+
+func (s SimpleLog) FrameBytes(bytes []byte) {
+	if s.Opts.ClientTrace() {
+	}
 }
 
 // Call

--- a/rpc/log_test_util.go
+++ b/rpc/log_test_util.go
@@ -23,3 +23,7 @@ func (t testLogOutput) Debug(fmt string, args ...interface{})                 { 
 func (t testLogOutput) Warning(fmt string, args ...interface{})               { t.log("W", fmt, args) }
 func (t testLogOutput) Profile(fmt string, args ...interface{})               { t.log("P", fmt, args) }
 func (t testLogOutput) CloneWithAddedDepth(depth int) LogOutputWithDepthAdder { return t }
+
+func newTestLog(t TestLogger) SimpleLog {
+	return SimpleLog{nil, testLogOutput{t}, SimpleLogOptions{}}
+}

--- a/rpc/log_test_util.go
+++ b/rpc/log_test_util.go
@@ -1,0 +1,25 @@
+package rpc
+
+import "fmt"
+
+// TestLogger is an interface for things, like *testing.T, that have a
+// Logf function.
+type TestLogger interface {
+	Logf(format string, args ...interface{})
+}
+
+type testLogOutput struct {
+	t TestLogger
+}
+
+func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
+	fmts = fmt.Sprintf("[%s] %s", ch, fmts)
+	t.t.Logf(fmts, args...)
+}
+
+func (t testLogOutput) Info(fmt string, args ...interface{})                  { t.log("I", fmt, args) }
+func (t testLogOutput) Error(fmt string, args ...interface{})                 { t.log("E", fmt, args) }
+func (t testLogOutput) Debug(fmt string, args ...interface{})                 { t.log("D", fmt, args) }
+func (t testLogOutput) Warning(fmt string, args ...interface{})               { t.log("W", fmt, args) }
+func (t testLogOutput) Profile(fmt string, args ...interface{})               { t.log("P", fmt, args) }
+func (t testLogOutput) CloneWithAddedDepth(depth int) LogOutputWithDepthAdder { return t }

--- a/rpc/log_test_util.go
+++ b/rpc/log_test_util.go
@@ -3,9 +3,10 @@ package rpc
 import "fmt"
 
 // TestLogger is an interface for things, like *testing.T, that have a
-// Logf function.
+// Logf and Helper function.
 type TestLogger interface {
 	Logf(format string, args ...interface{})
+	Helper()
 }
 
 type testLogOutput struct {
@@ -13,15 +14,36 @@ type testLogOutput struct {
 }
 
 func (t testLogOutput) log(ch string, fmts string, args []interface{}) {
+	t.t.Helper()
 	fmts = fmt.Sprintf("[%s] %s", ch, fmts)
 	t.t.Logf(fmts, args...)
 }
 
-func (t testLogOutput) Info(fmt string, args ...interface{})                  { t.log("I", fmt, args) }
-func (t testLogOutput) Error(fmt string, args ...interface{})                 { t.log("E", fmt, args) }
-func (t testLogOutput) Debug(fmt string, args ...interface{})                 { t.log("D", fmt, args) }
-func (t testLogOutput) Warning(fmt string, args ...interface{})               { t.log("W", fmt, args) }
-func (t testLogOutput) Profile(fmt string, args ...interface{})               { t.log("P", fmt, args) }
+func (t testLogOutput) Info(fmt string, args ...interface{}) {
+	t.t.Helper()
+	t.log("I", fmt, args)
+}
+
+func (t testLogOutput) Error(fmt string, args ...interface{}) {
+	t.t.Helper()
+	t.log("E", fmt, args)
+}
+
+func (t testLogOutput) Debug(fmt string, args ...interface{}) {
+	t.t.Helper()
+	t.log("D", fmt, args)
+}
+
+func (t testLogOutput) Warning(fmt string, args ...interface{}) {
+	t.t.Helper()
+	t.log("W", fmt, args)
+}
+
+func (t testLogOutput) Profile(fmt string, args ...interface{}) {
+	t.t.Helper()
+	t.log("P", fmt, args)
+}
+
 func (t testLogOutput) CloneWithAddedDepth(depth int) LogOutputWithDepthAdder { return t }
 
 func newTestLog(t TestLogger) SimpleLog {

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -34,7 +34,7 @@ func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
 	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)
 
-	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	log := newTestLog(t)
 	pkt := newPacketHandler(&buf, createMessageTestProtocol(), cc, log)
 
 	err := <-enc.EncodeAndWrite(c.ctx, v, nil)

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -33,7 +33,11 @@ func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
 	cc := newCallContainer()
 	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)
-	pkt := newPacketHandler(&buf, createMessageTestProtocol(), cc)
+
+	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
+	log := logFactory.NewLog(nil)
+
+	pkt := newPacketHandler(&buf, createMessageTestProtocol(), cc, log)
 
 	err := <-enc.EncodeAndWrite(c.ctx, v, nil)
 	require.Nil(t, err, "expected encoding to succeed")

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -34,9 +34,7 @@ func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
 	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)
 
-	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
-	log := logFactory.NewLog(nil)
-
+	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
 	pkt := newPacketHandler(&buf, createMessageTestProtocol(), cc, log)
 
 	err := <-enc.EncodeAndWrite(c.ctx, v, nil)

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -91,40 +91,40 @@ func TestMessageDecodeInvalidType(t *testing.T) {
 
 	_, err := runMessageTest(t, v)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "RPC error. type: -1, method: , length: 4, error: error decoding message field at position 0, error: ")
+	require.Contains(t, err.Error(), "RPC error. type: Invalid, method: , length: 4, error: error decoding message field at position 0, error: ")
 }
 
 func TestMessageDecodeInvalidMethodType(t *testing.T) {
 	v := []interface{}{MethodType(999), SeqNumber(0), "invalid", new(interface{})}
 
 	_, err := runMessageTest(t, v)
-	require.EqualError(t, err, "RPC error. type: 999, method: , length: 4, error: invalid RPC type")
+	require.EqualError(t, err, "RPC error. type: Method(999), method: , length: 4, error: invalid RPC type")
 }
 
 func TestMessageDecodeInvalidProtocol(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "nonexistent.broken", new(interface{})}
 
 	_, err := runMessageTest(t, v)
-	require.EqualError(t, err, "RPC error. type: 0, method: nonexistent.broken, length: 4, error: protocol not found: nonexistent")
+	require.EqualError(t, err, "RPC error. type: Call, method: nonexistent.broken, length: 4, error: protocol not found: nonexistent")
 }
 
 func TestMessageDecodeInvalidMethod(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid", new(interface{})}
 
 	_, err := runMessageTest(t, v)
-	require.EqualError(t, err, "RPC error. type: 0, method: abc.invalid, length: 4, error: method 'invalid' not found in protocol 'abc'")
+	require.EqualError(t, err, "RPC error. type: Call, method: abc.invalid, length: 4, error: method 'invalid' not found in protocol 'abc'")
 }
 
 func TestMessageDecodeWrongMessageLength(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid"}
 
 	_, err := runMessageTest(t, v)
-	require.EqualError(t, err, "RPC error. type: 0, method: , length: 3, error: wrong message length")
+	require.EqualError(t, err, "RPC error. type: Call, method: , length: 3, error: wrong message length")
 }
 
 func TestMessageDecodeResponseNilCall(t *testing.T) {
 	v := []interface{}{MethodResponse, SeqNumber(-1), 32, "hi"}
 
 	_, err := runMessageTest(t, v)
-	require.EqualError(t, err, "RPC error. type: 1, method: , length: 4, error: Call not found for sequence number -1")
+	require.EqualError(t, err, "RPC error. type: Response, method: , length: 4, error: Call not found for sequence number -1")
 }

--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -69,8 +69,8 @@ func (p *packetHandler) NextFrame() (rpcMessage, error) {
 		return nil, NewPacketizerError("invalid frame size: %d", len(bytes))
 	}
 
-	// Log the bytes as the last thing, to rule out the
-	// possibility of the logger mutating those bytes.
+	// Log the bytes as the last thing, just in case the logger
+	// mutates those bytes (which it shouldn't).
 	defer func() {
 		p.log.FrameRead(bytes)
 	}()

--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -72,6 +72,7 @@ func (p *packetHandler) NextFrame() (rpcMessage, error) {
 	// Log the bytes as the last thing, to rule out the
 	// possibility of the logger mutating those bytes.
 	defer func() {
+		p.log.FrameRead(bytes)
 	}()
 
 	// Attempt to read the fixarray

--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -31,9 +31,10 @@ type packetHandler struct {
 	fieldDecoder  *fieldDecoder
 	protocols     *protocolHandler
 	calls         *callContainer
+	log           LogInterface
 }
 
-func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callContainer) *packetHandler {
+func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callContainer, log LogInterface) *packetHandler {
 	wrappedReader := &lastErrReader{reader, nil}
 	return &packetHandler{
 		lengthDecoder: codec.NewDecoder(wrappedReader, newCodecMsgpackHandle()),
@@ -41,6 +42,7 @@ func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callC
 		fieldDecoder:  newFieldDecoder(),
 		protocols:     protocols,
 		calls:         calls,
+		log:           log,
 	}
 }
 
@@ -66,6 +68,11 @@ func (p *packetHandler) NextFrame() (rpcMessage, error) {
 	if len(bytes) < 1 {
 		return nil, NewPacketizerError("invalid frame size: %d", len(bytes))
 	}
+
+	// Log the bytes as the last thing, to rule out the
+	// possibility of the logger mutating those bytes.
+	defer func() {
+	}()
 
 	// Attempt to read the fixarray
 	nb := int(bytes[0])

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -57,7 +57,7 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	c := cc.NewCall(ctx, "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)
 
-	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	log := newTestLog(t)
 	pkt := newPacketHandler(&buf, createPacketizerTestProtocol(), cc, log)
 
 	f1, err := pkt.NextFrame()
@@ -113,7 +113,7 @@ func (r errReader) Read([]byte) (int, error) {
 }
 
 func TestPacketizerReaderOpError(t *testing.T) {
-	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	log := newTestLog(t)
 
 	// Taking advantage here of opErr being a nil *net.OpError,
 	// but a non-nil error when used by errReader.

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -56,7 +56,9 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	cc := newCallContainer()
 	c := cc.NewCall(ctx, "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)
-	pkt := newPacketHandler(&buf, createPacketizerTestProtocol(), cc)
+
+	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	pkt := newPacketHandler(&buf, createPacketizerTestProtocol(), cc, log)
 
 	f1, err := pkt.NextFrame()
 	require.NoError(t, err)
@@ -111,10 +113,12 @@ func (r errReader) Read([]byte) (int, error) {
 }
 
 func TestPacketizerReaderOpError(t *testing.T) {
+	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+
 	// Taking advantage here of opErr being a nil *net.OpError,
 	// but a non-nil error when used by errReader.
 	var opErr *net.OpError
-	pkt := newPacketHandler(errReader{opErr}, createPacketizerTestProtocol(), newCallContainer())
+	pkt := newPacketHandler(errReader{opErr}, createPacketizerTestProtocol(), newCallContainer(), log)
 
 	bytes, err := pkt.loadNextFrame()
 	require.Nil(t, bytes)

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"fmt"
 	"sync"
 
 	"golang.org/x/net/context"
@@ -21,6 +22,23 @@ const (
 	MethodNotify   MethodType = 2
 	MethodCancel   MethodType = 3
 )
+
+func (t MethodType) String() string {
+	switch t {
+	case MethodInvalid:
+		return "Invalid"
+	case MethodCall:
+		return "Call"
+	case MethodResponse:
+		return "Response"
+	case MethodNotify:
+		return "Notify"
+	case MethodCancel:
+		return "Cancel"
+	default:
+		return fmt.Sprintf("Method(%d)", t)
+	}
+}
 
 type ErrorUnwrapper interface {
 	MakeArg() interface{}

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -17,7 +17,7 @@ func testReceive(t *testing.T, p *Protocol, rpc rpcMessage) (receiver, chan erro
 		protHandler.registerProtocol(*p)
 	}
 
-	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	log := newTestLog(t)
 	pkt := newPacketHandler(conn1, protHandler, newCallContainer(), log)
 
 	r := newReceiveHandler(receiveOut, protHandler, log)

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -16,10 +16,11 @@ func testReceive(t *testing.T, p *Protocol, rpc rpcMessage) (receiver, chan erro
 	if p != nil {
 		protHandler.registerProtocol(*p)
 	}
-	pkt := newPacketHandler(conn1, protHandler, newCallContainer())
-	logFactory := NewSimpleLogFactory(SimpleLogOutput{}, SimpleLogOptions{})
 
-	r := newReceiveHandler(receiveOut, protHandler, logFactory.NewLog(nil))
+	log := SimpleLog{nil, SimpleLogOutput{}, SimpleLogOptions{}}
+	pkt := newPacketHandler(conn1, protHandler, newCallContainer(), log)
+
+	r := newReceiveHandler(receiveOut, protHandler, log)
 
 	errCh := make(chan error, 1)
 	err := r.Receive(rpc)

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -97,7 +97,7 @@ func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc) Transporter {
 	ret.enc = enc
 	ret.dispatcher = newDispatch(enc, ret.calls, log)
 	ret.receiver = newReceiveHandler(enc, ret.protocols, log)
-	ret.packetizer = newPacketHandler(cdec.Reader, ret.protocols, ret.calls)
+	ret.packetizer = newPacketHandler(cdec.Reader, ret.protocols, ret.calls, log)
 	return ret
 }
 


### PR DESCRIPTION
A hacked-up version of this let me debug a weird Windows RPC issue.

Make all tests log to *testing.T.

Add String method for MessageType (for logging).

Use t.Helper() in a few places (which bumps up the minimum Go version).