### PR TITLE
connection: disrupt the backoff timer on every retry

### DIFF
--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -530,10 +530,11 @@ func (c *Connection) connect(ctx context.Context) error {
 // DoCommand executes the specific rpc command wrapped in rpcFunc.
 func (c *Connection) DoCommand(ctx context.Context, name string,
 	rpcFunc func(GenericClient) error) error {
-	if c.initialReconnectBackoffWindow != nil && isWithFireNow(ctx) {
-		c.randomTimer.FireNow()
-	}
 	for {
+		if c.initialReconnectBackoffWindow != nil && isWithFireNow(ctx) {
+			c.randomTimer.FireNow()
+		}
+
 		// we may or may not be in the process of reconnecting.
 		// if so we'll block here unless canceled by the caller.
 		connErr := c.waitForConnection(ctx, false)


### PR DESCRIPTION
If an RPC is in flight when a TCP connection goes down, it gets an EIO error.  If the RPC handler's `ShouldRetry()` method doesn't return true for an EIO, it gets retried by the RPC connection itself.  But it'll just loop back up into `waitForConnection()`, and the service might have chosen a very long backoff timer to re-establish the connection (in an effort to prevent thundering herds).

New RPC calls can override this by causing the random backoff timer to fire immediately, but in-flight RPCs didn't do that on retries.

Until now.

Issue: KBFS-3404