### PR TITLE
Remove some interfaces with only a single implementation

### DIFF
--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -7,11 +7,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-type encoder interface {
-	EncodeAndWrite(context.Context, interface{}, func()) <-chan error
-	EncodeAndWriteAsync(interface{}) <-chan error
-}
-
 // fieldDecoder decodes the fields of a packet.
 type fieldDecoder struct {
 	d           *codec.Decoder

--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -92,8 +92,10 @@ func (e *framedMsgpackEncoder) encodeFrame(i interface{}) ([]byte, error) {
 	return append(length, content...), nil
 }
 
-func (e *framedMsgpackEncoder) EncodeAndWrite(ctx context.Context, i interface{}, sendNotifier func()) <-chan error {
-	bytes, err := e.encodeFrame(i)
+// encodeAndWriteInternal is called directly by tests that need to
+// write invalid frames.
+func (e *framedMsgpackEncoder) encodeAndWriteInternal(ctx context.Context, frame interface{}, sendNotifier func()) <-chan error {
+	bytes, err := e.encodeFrame(frame)
 	ch := make(chan error, 1)
 	if err != nil {
 		ch <- err
@@ -109,8 +111,12 @@ func (e *framedMsgpackEncoder) EncodeAndWrite(ctx context.Context, i interface{}
 	return ch
 }
 
-func (e *framedMsgpackEncoder) EncodeAndWriteAsync(i interface{}) <-chan error {
-	bytes, err := e.encodeFrame(i)
+func (e *framedMsgpackEncoder) EncodeAndWrite(ctx context.Context, frame []interface{}, sendNotifier func()) <-chan error {
+	return e.encodeAndWriteInternal(ctx, frame, sendNotifier)
+}
+
+func (e *framedMsgpackEncoder) EncodeAndWriteAsync(frame []interface{}) <-chan error {
+	bytes, err := e.encodeFrame(frame)
 	ch := make(chan error, 1)
 	if err != nil {
 		ch <- err

--- a/rpc/dispatch.go
+++ b/rpc/dispatch.go
@@ -13,7 +13,7 @@ type dispatcher interface {
 }
 
 type dispatch struct {
-	writer encoder
+	writer *framedMsgpackEncoder
 	calls  *callContainer
 
 	// Stops all loops when closed
@@ -24,7 +24,7 @@ type dispatch struct {
 	log LogInterface
 }
 
-func newDispatch(enc encoder, calls *callContainer, l LogInterface) *dispatch {
+func newDispatch(enc *framedMsgpackEncoder, calls *callContainer, l LogInterface) *dispatch {
 	d := &dispatch{
 		writer:   enc,
 		calls:    calls,

--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -8,10 +8,6 @@ import (
 	"github.com/keybase/go-codec/codec"
 )
 
-type packetizer interface {
-	NextFrame() (rpcMessage, error)
-}
-
 // lastErrReader stores the last error returned by its child
 // reader. It's used by loadNextFrame below.
 type lastErrReader struct {

--- a/rpc/packetizer.go
+++ b/rpc/packetizer.go
@@ -21,7 +21,7 @@ func (r *lastErrReader) Read(buf []byte) (int, error) {
 	return n, err
 }
 
-type packetHandler struct {
+type packetizer struct {
 	lengthDecoder *codec.Decoder
 	reader        *lastErrReader
 	fieldDecoder  *fieldDecoder
@@ -30,9 +30,9 @@ type packetHandler struct {
 	log           LogInterface
 }
 
-func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callContainer, log LogInterface) *packetHandler {
+func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callContainer, log LogInterface) *packetizer {
 	wrappedReader := &lastErrReader{reader, nil}
-	return &packetHandler{
+	return &packetizer{
 		lengthDecoder: codec.NewDecoder(wrappedReader, newCodecMsgpackHandle()),
 		reader:        wrappedReader,
 		fieldDecoder:  newFieldDecoder(),
@@ -56,7 +56,7 @@ func newPacketHandler(reader io.Reader, protocols *protocolHandler, calls *callC
 //     rpcMessage will be non-nil, and its Err() will match this
 //     error. We can then process the error and continue with the next
 //     packet.
-func (p *packetHandler) NextFrame() (rpcMessage, error) {
+func (p *packetizer) NextFrame() (rpcMessage, error) {
 	bytes, err := p.loadNextFrame()
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (p *packetHandler) NextFrame() (rpcMessage, error) {
 	return decodeRPC(nb-0x90, p.fieldDecoder, p.protocols, p.calls)
 }
 
-func (p *packetHandler) loadNextFrame() ([]byte, error) {
+func (p *packetizer) loadNextFrame() ([]byte, error) {
 	// Get the packet length
 	var l int
 	if err := p.lengthDecoder.Decode(&l); err != nil {

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -49,7 +49,7 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	enc := newFramedMsgpackEncoder(&buf)
 	ctx := context.Background()
 	for _, frame := range frames {
-		err := <-enc.EncodeAndWrite(ctx, frame, nil)
+		err := <-enc.encodeAndWriteInternal(ctx, frame, nil)
 		require.NoError(t, err)
 	}
 

--- a/rpc/receiver.go
+++ b/rpc/receiver.go
@@ -13,7 +13,7 @@ type receiver interface {
 }
 
 type receiveHandler struct {
-	writer      encoder
+	writer      *framedMsgpackEncoder
 	protHandler *protocolHandler
 
 	tasks map[int]context.CancelFunc
@@ -31,7 +31,7 @@ type receiveHandler struct {
 	log LogInterface
 }
 
-func newReceiveHandler(enc encoder, protHandler *protocolHandler, l LogInterface) *receiveHandler {
+func newReceiveHandler(enc *framedMsgpackEncoder, protHandler *protocolHandler, l LogInterface) *receiveHandler {
 	r := &receiveHandler{
 		writer:      enc,
 		protHandler: protHandler,

--- a/rpc/request.go
+++ b/rpc/request.go
@@ -7,8 +7,8 @@ import (
 type request interface {
 	rpcMessage
 	CancelFunc() context.CancelFunc
-	Reply(encoder, interface{}, interface{}) error
-	Serve(encoder, *ServeHandlerDescription, WrapErrorFunc)
+	Reply(*framedMsgpackEncoder, interface{}, interface{}) error
+	Serve(*framedMsgpackEncoder, *ServeHandlerDescription, WrapErrorFunc)
 	LogInvocation(err error)
 	LogCompletion(res interface{}, err error)
 }
@@ -48,7 +48,7 @@ func (r *callRequest) LogCompletion(res interface{}, err error) {
 	r.log.ServerReply(r.SeqNo(), r.Name(), err, res)
 }
 
-func (r *callRequest) Reply(enc encoder, res interface{}, errArg interface{}) (err error) {
+func (r *callRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg interface{}) (err error) {
 	v := []interface{}{
 		MethodResponse,
 		r.SeqNo(),
@@ -67,7 +67,7 @@ func (r *callRequest) Reply(enc encoder, res interface{}, errArg interface{}) (e
 	return err
 }
 
-func (r *callRequest) Serve(transmitter encoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
+func (r *callRequest) Serve(transmitter *framedMsgpackEncoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
 
 	prof := r.log.StartProfiler("serve %s", r.Name())
 	arg := r.Arg()
@@ -105,7 +105,7 @@ func (r *notifyRequest) LogCompletion(_ interface{}, err error) {
 	r.log.ServerNotifyComplete(r.Name(), err)
 }
 
-func (r *notifyRequest) Serve(transmitter encoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
+func (r *notifyRequest) Serve(transmitter *framedMsgpackEncoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
 
 	prof := r.log.StartProfiler("serve-notify %s", r.Name())
 	arg := r.Arg()
@@ -116,6 +116,6 @@ func (r *notifyRequest) Serve(transmitter encoder, handler *ServeHandlerDescript
 	r.LogCompletion(nil, err)
 }
 
-func (r *notifyRequest) Reply(enc encoder, res interface{}, errArg interface{}) (err error) {
+func (r *notifyRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg interface{}) (err error) {
 	return nil
 }

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -67,7 +67,7 @@ type transport struct {
 	enc        *framedMsgpackEncoder
 	dispatcher dispatcher
 	receiver   receiver
-	packetizer packetizer
+	packetizer *packetHandler
 	protocols  *protocolHandler
 	calls      *callContainer
 	log        LogInterface

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -67,7 +67,7 @@ type transport struct {
 	enc        *framedMsgpackEncoder
 	dispatcher dispatcher
 	receiver   receiver
-	packetizer *packetHandler
+	packetizer *packetizer
 	protocols  *protocolHandler
 	calls      *callContainer
 	log        LogInterface


### PR DESCRIPTION
They don't really add anything, and confuse IDE integrations.