### PR TITLE
Make frame encoder respect the frame bounds

### DIFF
--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/keybase/go-codec/codec"
@@ -58,6 +59,9 @@ func (e *framedMsgpackEncoder) encodeFrame(i interface{}) ([]byte, error) {
 	content, err := encodeToBytes(enc, i)
 	if err != nil {
 		return nil, err
+	}
+	if len(content) > int(e.maxFrameLength) {
+		return nil, fmt.Errorf("frame length too big: %d > %d", len(content), e.maxFrameLength)
 	}
 	length, err := encodeToBytes(enc, len(content))
 	if err != nil {

--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -26,38 +26,40 @@ type writeBundle struct {
 }
 
 type framedMsgpackEncoder struct {
-	handle   codec.Handle
-	writer   io.Writer
-	writeCh  chan writeBundle
-	doneCh   chan struct{}
-	closedCh chan struct{}
+	maxFrameLength int32
+	handle         codec.Handle
+	writer         io.Writer
+	writeCh        chan writeBundle
+	doneCh         chan struct{}
+	closedCh       chan struct{}
 }
 
-func newFramedMsgpackEncoder(writer io.Writer) *framedMsgpackEncoder {
+func newFramedMsgpackEncoder(maxFrameLength int32, writer io.Writer) *framedMsgpackEncoder {
 	e := &framedMsgpackEncoder{
-		handle:   newCodecMsgpackHandle(),
-		writer:   writer,
-		writeCh:  make(chan writeBundle),
-		doneCh:   make(chan struct{}),
-		closedCh: make(chan struct{}),
+		maxFrameLength: maxFrameLength,
+		handle:         newCodecMsgpackHandle(),
+		writer:         writer,
+		writeCh:        make(chan writeBundle),
+		doneCh:         make(chan struct{}),
+		closedCh:       make(chan struct{}),
 	}
 	go e.writerLoop()
 	return e
 }
 
-func (e *framedMsgpackEncoder) encodeToBytes(enc *codec.Encoder, i interface{}) (v []byte, err error) {
+func encodeToBytes(enc *codec.Encoder, i interface{}) (v []byte, err error) {
 	enc.ResetBytes(&v)
 	err = enc.Encode(i)
 	return v, err
 }
 
 func (e *framedMsgpackEncoder) encodeFrame(i interface{}) ([]byte, error) {
-	enc := codec.NewEncoderBytes(&[]byte{}, e.handle)
-	content, err := e.encodeToBytes(enc, i)
+	enc := codec.NewEncoderBytes(nil, e.handle)
+	content, err := encodeToBytes(enc, i)
 	if err != nil {
 		return nil, err
 	}
-	length, err := e.encodeToBytes(enc, len(content))
+	length, err := encodeToBytes(enc, len(content))
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -13,7 +13,7 @@ func dispatchTestCallWithContext(t *testing.T, ctx context.Context) (dispatcher,
 	log := newTestLog(t)
 
 	conn1, conn2 := net.Pipe()
-	dispatchOut := newFramedMsgpackEncoder(conn1)
+	dispatchOut := newFramedMsgpackEncoder(testMaxFrameLength, conn1)
 	calls := newCallContainer()
 	pkt := newPacketizer(testMaxFrameLength, conn2, createMessageTestProtocol(), calls, log)
 
@@ -123,7 +123,7 @@ func TestDispatchCallAfterClose(t *testing.T) {
 
 func TestDispatchCancelEndToEnd(t *testing.T) {
 	dispatchConn, _ := net.Pipe()
-	enc := newFramedMsgpackEncoder(dispatchConn)
+	enc := newFramedMsgpackEncoder(testMaxFrameLength, dispatchConn)
 	cc := newCallContainer()
 	log := newTestLog(t)
 	d := newDispatch(enc, cc, log)

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -29,7 +29,7 @@ func createMessageTestProtocol() *protocolHandler {
 
 func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
 	var buf bytes.Buffer
-	enc := newFramedMsgpackEncoder(&buf)
+	enc := newFramedMsgpackEncoder(testMaxFrameLength, &buf)
 	cc := newCallContainer()
 	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), nil)
 	cc.AddCall(c)

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -199,7 +199,7 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	frames := []interface{}{v1, iv1, iv2, v2, iv3, v3, iv4, v4}
 
 	var buf bytes.Buffer
-	enc := newFramedMsgpackEncoder(&buf)
+	enc := newFramedMsgpackEncoder(testMaxFrameLength, &buf)
 	ctx := context.Background()
 	for _, frame := range frames {
 		err := <-enc.encodeAndWriteInternal(ctx, frame, nil)

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -79,6 +79,15 @@ func TestBrokenCall(t *testing.T) {
 	require.EqualError(t, err, "protocol not found: test.2.testp")
 }
 
+func TestCallLargeFrame(t *testing.T) {
+	cli, listener, conn := prepTest(t)
+	defer endTest(t, conn, listener)
+
+	var padding [testMaxFrameLength]byte
+	_, err := cli.Add(context.Background(), AddArgs{A: 1, B: 1, Padding: padding[:]})
+	require.NoError(t, err)
+}
+
 func TestNotify(t *testing.T) {
 	cli, listener, conn := prepTest(t)
 	defer endTest(t, conn, listener)

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -85,6 +85,9 @@ func TestCallLargeFrame(t *testing.T) {
 
 	var padding [testMaxFrameLength]byte
 	_, err := cli.Add(context.Background(), AddArgs{A: 1, B: 1, Padding: padding[:]})
+	require.EqualError(t, err, "something something")
+
+	_, err = cli.Add(context.Background(), AddArgs{A: 1, B: 1})
 	require.NoError(t, err)
 }
 

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -85,8 +85,9 @@ func TestCallLargeFrame(t *testing.T) {
 
 	var padding [testMaxFrameLength]byte
 	_, err := cli.Add(context.Background(), AddArgs{A: 1, B: 1, Padding: padding[:]})
-	require.EqualError(t, err, "something something")
+	require.EqualError(t, err, "frame length too big: 1062 > 1024")
 
+	// Shouldn't close the whole connection.
 	_, err = cli.Add(context.Background(), AddArgs{A: 1, B: 1})
 	require.NoError(t, err)
 }

--- a/rpc/protocol_utils_test.go
+++ b/rpc/protocol_utils_test.go
@@ -107,8 +107,9 @@ func (a *testProtocol) LongCallDebugTags(ctx context.Context) (CtxRpcTags, error
 // begin autogen code
 
 type AddArgs struct {
-	A int
-	B int
+	A       int
+	B       int
+	Padding []byte
 }
 
 type Constants struct {

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -10,7 +10,7 @@ import (
 
 func testReceive(t *testing.T, p *Protocol, rpc rpcMessage) (receiver, chan error) {
 	conn1, conn2 := net.Pipe()
-	receiveOut := newFramedMsgpackEncoder(conn2)
+	receiveOut := newFramedMsgpackEncoder(testMaxFrameLength, conn2)
 
 	protHandler := createMessageTestProtocol()
 	if p != nil {

--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -72,7 +72,7 @@ func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc, maxFrameLength in
 		protocols: newProtocolHandler(wef),
 		calls:     newCallContainer(),
 	}
-	enc := newFramedMsgpackEncoder(c)
+	enc := newFramedMsgpackEncoder(maxFrameLength, c)
 	ret.enc = enc
 	ret.dispatcher = newDispatch(enc, ret.calls, log)
 	ret.receiver = newReceiveHandler(enc, ret.protocols, log)


### PR DESCRIPTION
This'll give a better error on the client side; otherwise, the server would close
the connection.