### PR TITLE
Panic on non-positive maxFrameLength

### DIFF
--- a/rpc/transport.go
+++ b/rpc/transport.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -60,6 +61,10 @@ type transport struct {
 }
 
 func NewTransport(c net.Conn, l LogFactory, wef WrapErrorFunc, maxFrameLength int32) Transporter {
+	if maxFrameLength <= 0 {
+		panic(fmt.Sprintf("maxFrameLength must be positive: got %d", maxFrameLength))
+	}
+
 	if l == nil {
 		l = NewSimpleLogFactory(nil, nil)
 	}


### PR DESCRIPTION
Otherwise, a server would just drop incoming connections on the first packet,
which would be difficult to diagnose.