### PR TITLE
CallCompressed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 go:
   - 1.9.x
   - 1.10.x
+  - 1.11.x
 script: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 go-framed-msgpack-rpc
 =====================
 
+[![Travis CI](https://travis-ci.org/keybase/go-framed-msgpack-rpc.svg?branch=master)](https://travis-ci.org/keybase/go-framed-msgpack-rpc)
+
 Framed RPC for go.

--- a/rpc/call.go
+++ b/rpc/call.go
@@ -15,6 +15,7 @@ type call struct {
 	seqid          SeqNumber
 	arg            interface{}
 	res            interface{}
+	ctype          CompressionType
 	errorUnwrapper ErrorUnwrapper
 }
 
@@ -32,7 +33,8 @@ func newCallContainer() *callContainer {
 	}
 }
 
-func (cc *callContainer) NewCall(ctx context.Context, m string, arg interface{}, res interface{}, u ErrorUnwrapper) *call {
+func (cc *callContainer) NewCall(ctx context.Context, m string, arg interface{}, res interface{},
+	ctype CompressionType, u ErrorUnwrapper) *call {
 	// Buffer one response to take into account that a call stops
 	// waiting for its result when its canceled. (See
 	// https://github.com/keybase/go-framed-msgpack-rpc/issues/62
@@ -43,6 +45,7 @@ func (cc *callContainer) NewCall(ctx context.Context, m string, arg interface{},
 		method:         m,
 		arg:            arg,
 		res:            res,
+		ctype:          ctype,
 		errorUnwrapper: u,
 		seqid:          cc.nextSeqid(),
 	}

--- a/rpc/codec.go
+++ b/rpc/codec.go
@@ -74,9 +74,9 @@ func (e *framedMsgpackEncoder) compressResponse(ctype CompressionType, res inter
 	return i, nil
 }
 
-func (e *framedMsgpackEncoder) encodeFrame(i interface{}) (content []byte, err error) {
+func (e *framedMsgpackEncoder) encodeFrame(i interface{}) ([]byte, error) {
 	enc := codec.NewEncoderBytes(nil, e.handle)
-	content, err = encodeToBytes(enc, i)
+	content, err := encodeToBytes(enc, i)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/compressor.go
+++ b/rpc/compressor.go
@@ -1,0 +1,86 @@
+package rpc
+
+import (
+	"bytes"
+	"compress/gzip"
+)
+
+type compressor interface {
+	Compress([]byte) ([]byte, error)
+	Decompress([]byte) ([]byte, error)
+}
+
+type gzipCompressor struct {
+	writer *gzip.Writer
+	reader *gzip.Reader
+}
+
+var _ compressor = (*gzipCompressor)(nil)
+
+func newGzipCompressor() *gzipCompressor {
+	return &gzipCompressor{}
+}
+
+func (c *gzipCompressor) Compress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if c.writer == nil {
+		c.writer = gzip.NewWriter(&buf)
+	} else {
+		c.writer.Reset(&buf)
+	}
+
+	if _, err := c.writer.Write(data); err != nil {
+		return nil, err
+	}
+	if err := c.writer.Flush(); err != nil {
+		return nil, err
+	}
+	if err := c.writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *gzipCompressor) Decompress(data []byte) ([]byte, error) {
+	in := bytes.NewBuffer(data)
+	if c.reader == nil {
+		var err error
+		c.reader, err = gzip.NewReader(in)
+		if err != nil {
+			c.reader = nil
+			return nil, err
+		}
+	} else {
+		if err := c.reader.Reset(in); err != nil {
+			return nil, err
+		}
+	}
+
+	var out bytes.Buffer
+	if _, err := out.ReadFrom(c.reader); err != nil {
+		return nil, err
+	}
+	if err := c.reader.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
+type compressorCacher struct {
+	algs map[CompressionType]compressor
+}
+
+func newCompressorCacher() *compressorCacher {
+	return &compressorCacher{
+		algs: make(map[CompressionType]compressor),
+	}
+}
+
+func (c *compressorCacher) getCompressor(ctype CompressionType) compressor {
+	impl, ok := c.algs[ctype]
+	if !ok {
+		impl = ctype.NewCompressor()
+		c.algs[ctype] = impl
+	}
+	return impl
+}

--- a/rpc/compressor.go
+++ b/rpc/compressor.go
@@ -44,12 +44,11 @@ func (c *gzipCompressor) Compress(data []byte) ([]byte, error) {
 func (c *gzipCompressor) Decompress(data []byte) ([]byte, error) {
 	in := bytes.NewBuffer(data)
 	if c.reader == nil {
-		var err error
-		c.reader, err = gzip.NewReader(in)
+		reader, err := gzip.NewReader(in)
 		if err != nil {
-			c.reader = nil
 			return nil, err
 		}
+		c.reader = reader
 	} else {
 		if err := c.reader.Reset(in); err != nil {
 			return nil, err

--- a/rpc/compressor_test.go
+++ b/rpc/compressor_test.go
@@ -10,8 +10,8 @@ func TestGzip(t *testing.T) {
 	c := newCompressorCacher()
 
 	// Make sure we don't make multiple instances of compressors
-	_ = c.getCompressor(CompressionGzip)
 	gz := c.getCompressor(CompressionGzip)
+	c.getCompressor(CompressionGzip)
 	none := c.getCompressor(CompressionNone)
 	require.Nil(t, none)
 	require.Len(t, c.algs, 2)

--- a/rpc/compressor_test.go
+++ b/rpc/compressor_test.go
@@ -1,0 +1,38 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGzip(t *testing.T) {
+	c := newCompressorCacher()
+
+	// Make sure we don't make multiple instances of compressors
+	_ = c.getCompressor(CompressionGzip)
+	gz := c.getCompressor(CompressionGzip)
+	none := c.getCompressor(CompressionNone)
+	require.Nil(t, none)
+	require.Len(t, c.algs, 2)
+
+	data := []byte("gzip me")
+	zipped, err := gz.Compress(data)
+	require.NoError(t, err)
+
+	unzipped, err := gz.Decompress(zipped)
+	require.NoError(t, err)
+	require.Equal(t, data, unzipped)
+
+	garbage, err := gz.Decompress(data)
+	require.Error(t, err)
+	require.Nil(t, garbage)
+
+	// compress/decompress again to test reader/writer reuse
+	zipped2, err := gz.Compress(data)
+	require.NoError(t, err)
+	unzipped2, err := gz.Decompress(zipped2)
+	require.NoError(t, err)
+	require.Equal(t, data, unzipped2)
+	require.Equal(t, unzipped, unzipped2)
+}

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -325,6 +325,9 @@ type Connection struct {
 
 	initialReconnectBackoffWindow func() time.Duration
 	randomTimer                   CancellableRandomTimer
+
+	// for tests
+	reconnectCompleteForTest chan struct{}
 }
 
 // This struct contains all the connection parameters that are optional. The
@@ -487,6 +490,12 @@ func newConnectionWithTransportAndProtocols(handler ConnectionHandler,
 	return newConnectionWithTransportAndProtocolsWithLog(
 		handler, transport, errorUnwrapper,
 		newConnectionLogUnstructured(log, "CONN "+handler.HandlerName()), opts)
+}
+
+func (c *Connection) setReconnectCompleteForTest(ch chan struct{}) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.reconnectCompleteForTest = ch
 }
 
 // connect performs the actual connect() and rpc setup.
@@ -729,6 +738,10 @@ func (c *Connection) doReconnect(ctx context.Context, disconnectStatus Disconnec
 	c.reconnectChan = nil
 	c.cancelFunc = nil
 	c.reconnectErrPtr = nil
+	if c.reconnectCompleteForTest != nil {
+		close(c.reconnectCompleteForTest)
+		c.reconnectCompleteForTest = nil
+	}
 }
 
 // GetClient returns an RPC client that uses DoCommand() for RPC

--- a/rpc/connection.go
+++ b/rpc/connection.go
@@ -777,6 +777,13 @@ func (c connectionClient) Call(ctx context.Context, s string, args interface{}, 
 	})
 }
 
+func (c connectionClient) CallCompressed(ctx context.Context, s string,
+	args interface{}, res interface{}, ctype CompressionType) error {
+	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {
+		return rawClient.CallCompressed(ctx, s, args, res, ctype)
+	})
+}
+
 func (c connectionClient) Notify(ctx context.Context, s string, args interface{}) error {
 	return c.conn.DoCommand(ctx, s, func(rawClient GenericClient) error {
 		return rawClient.Notify(ctx, s, args)

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -107,7 +107,7 @@ func (ut *unitTester) WaitForDoneOrBust(t *testing.T,
 	case <-ut.doneChan:
 		break
 	case <-timer.C:
-		require.Fail(t, "%s timeout", opName)
+		require.Fail(t, fmt.Sprintf("%s timeout", opName))
 	}
 }
 

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -107,7 +107,7 @@ func (ut *unitTester) WaitForDoneOrBust(t *testing.T,
 	case <-ut.doneChan:
 		break
 	case <-timer.C:
-		t.Fatalf("%s timeout", opName)
+		require.Fail(t, "%s timeout", opName)
 	}
 }
 
@@ -142,9 +142,8 @@ func TestReconnectBasic(t *testing.T) {
 	case <-timeout:
 		break
 	}
-	if err := unitTester.Err(); err != nil {
-		t.Fatal(err)
-	}
+	err := unitTester.Err()
+	require.NoError(t, err)
 }
 
 // Test a basic reconnect flow.
@@ -197,9 +196,7 @@ func TestReconnectCanceled(t *testing.T) {
 	// Test that any command fails with the expected error.
 	err := conn.DoCommand(context.Background(), "test",
 		func(GenericClient) error { return nil })
-	if err != cancelErr {
-		t.Fatalf("Error wasn't InputCanceled: %v", err)
-	}
+	require.Equal(t, err, cancelErr)
 }
 
 // Test DoCommand with throttling.
@@ -236,10 +233,7 @@ func TestDoCommandThrottle(t *testing.T) {
 		}
 		return nil
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestConnectionClientCallError(t *testing.T) {

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -256,6 +256,20 @@ func TestConnectionClientCallError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestConnectionClientCallCompressedError(t *testing.T) {
+	serverConn, conn := MakeConnectionForTest(t)
+	defer conn.Shutdown()
+
+	c := connectionClient{conn}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.CallCompressed(context.Background(), "callRpc", nil, nil, CompressionGzip)
+	}()
+	serverConn.Close()
+	err := <-errCh
+	require.Error(t, err)
+}
+
 func TestConnectionClientNotifyError(t *testing.T) {
 	serverConn, conn := MakeConnectionForTest(t)
 	defer conn.Shutdown()

--- a/rpc/dispatch.go
+++ b/rpc/dispatch.go
@@ -7,7 +7,8 @@ import (
 )
 
 type dispatcher interface {
-	Call(ctx context.Context, name string, arg interface{}, res interface{}, u ErrorUnwrapper, sendNotifier SendNotifier) error
+	Call(ctx context.Context, name string, arg interface{}, res interface{},
+		ctype CompressionType, u ErrorUnwrapper, sendNotifier SendNotifier) error
 	Notify(ctx context.Context, name string, arg interface{}, sendNotifier SendNotifier) error
 	Close()
 }
@@ -45,21 +46,33 @@ func currySendNotifier(sendNotifier SendNotifier, seqid SeqNumber) func() {
 	}
 }
 
-func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res interface{}, u ErrorUnwrapper, sendNotifier SendNotifier) error {
+func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res interface{},
+	ctype CompressionType, u ErrorUnwrapper, sendNotifier SendNotifier) error {
 	profiler := d.log.StartProfiler("call %s", name)
 	defer profiler.Stop()
 
-	c := d.calls.NewCall(ctx, name, arg, res, u)
+	c := d.calls.NewCall(ctx, name, arg, res, ctype, u)
 
 	// Have to add call before encoding otherwise we'll race the response
 	d.calls.AddCall(c)
 	defer d.calls.RemoveCall(c.seqid)
+
+	var v []interface{}
+	var logCall func()
+	switch ctype {
+	case CompressionNone:
+		v = []interface{}{MethodCall, c.seqid, c.method, c.arg}
+		logCall = func() { d.log.ClientCall(c.seqid, c.method, c.arg) }
+	default:
+		v = []interface{}{MethodCallCompressed, c.seqid, c.ctype, c.method, c.arg}
+		logCall = func() { d.log.ClientCallCompressed(c.seqid, c.method, c.arg, c.ctype) }
+	}
+
 	rpcTags, _ := RpcTagsFromContext(ctx)
-	v := []interface{}{MethodCall, c.seqid, c.method, c.arg}
 	if len(rpcTags) > 0 {
 		v = append(v, rpcTags)
 	}
-	errCh := d.writer.EncodeAndWrite(ctx, v, currySendNotifier(sendNotifier, c.seqid))
+	errCh := d.writer.EncodeAndWrite(ctx, ctype, v, currySendNotifier(sendNotifier, c.seqid))
 
 	// Wait for result from encode
 	select {
@@ -73,7 +86,7 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 		return io.EOF
 	}
 
-	d.log.ClientCall(c.seqid, c.method, c.arg)
+	logCall()
 
 	// Wait for result from call
 	select {
@@ -93,7 +106,8 @@ func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}, sen
 	if len(rpcTags) > 0 {
 		v = append(v, rpcTags)
 	}
-	errCh := d.writer.EncodeAndWrite(ctx, v, currySendNotifier(sendNotifier, SeqNumber(-1)))
+	errCh := d.writer.EncodeAndWrite(ctx, CompressionNone,
+		v, currySendNotifier(sendNotifier, SeqNumber(-1)))
 	select {
 	case err := <-errCh:
 		if err == nil {
@@ -114,7 +128,7 @@ func (d *dispatch) Close() {
 
 func (d *dispatch) handleCancel(c *call) error {
 	d.log.ClientCancel(c.seqid, c.method, nil)
-	errCh := d.writer.EncodeAndWriteAsync([]interface{}{MethodCancel, c.seqid, c.method})
+	errCh := d.writer.EncodeAndWriteAsync(CompressionNone, []interface{}{MethodCancel, c.seqid, c.method})
 	select {
 	case err := <-errCh:
 		if err != nil {

--- a/rpc/dispatch.go
+++ b/rpc/dispatch.go
@@ -72,7 +72,7 @@ func (d *dispatch) Call(ctx context.Context, name string, arg interface{}, res i
 	if len(rpcTags) > 0 {
 		v = append(v, rpcTags)
 	}
-	errCh := d.writer.EncodeAndWrite(ctx, ctype, v, currySendNotifier(sendNotifier, c.seqid))
+	errCh := d.writer.EncodeAndWrite(ctx, v, currySendNotifier(sendNotifier, c.seqid))
 
 	// Wait for result from encode
 	select {
@@ -106,8 +106,7 @@ func (d *dispatch) Notify(ctx context.Context, name string, arg interface{}, sen
 	if len(rpcTags) > 0 {
 		v = append(v, rpcTags)
 	}
-	errCh := d.writer.EncodeAndWrite(ctx, CompressionNone,
-		v, currySendNotifier(sendNotifier, SeqNumber(-1)))
+	errCh := d.writer.EncodeAndWrite(ctx, v, currySendNotifier(sendNotifier, SeqNumber(-1)))
 	select {
 	case err := <-errCh:
 		if err == nil {
@@ -128,7 +127,7 @@ func (d *dispatch) Close() {
 
 func (d *dispatch) handleCancel(c *call) error {
 	d.log.ClientCancel(c.seqid, c.method, nil)
-	errCh := d.writer.EncodeAndWriteAsync(CompressionNone, []interface{}{MethodCancel, c.seqid, c.method})
+	errCh := d.writer.EncodeAndWriteAsync([]interface{}{MethodCancel, c.seqid, c.method})
 	select {
 	case err := <-errCh:
 		if err != nil {

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -60,10 +60,12 @@ func TestDispatchSuccessfulCall(t *testing.T) {
 }
 
 func TestDispatchSuccessfulCallCompressed(t *testing.T) {
-	d, calls, done := dispatchTestCallWithContextAndCompressionType(t, context.Background(), CompressionGzip)
+	ctype := CompressionGzip
+	d, calls, done := dispatchTestCallWithContextAndCompressionType(t, context.Background(), ctype)
 
 	c := calls.RetrieveCall(0)
 	require.NotNil(t, c, "Expected c not to be nil")
+	require.Equal(t, ctype, c.ctype)
 
 	sendResponse(c, nil)
 	err := <-done
@@ -78,6 +80,7 @@ func TestDispatchCanceledBeforeResult(t *testing.T) {
 
 	c := calls.RetrieveCall(0)
 	require.NotNil(t, c, "Expected c not to be nil")
+	require.Equal(t, CompressionNone, c.ctype)
 
 	cancel()
 

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -272,10 +272,12 @@ func (s SimpleLog) trace(which string, objname string, verbose bool, q SeqNumber
 		fmts += " method=%s;"
 		args = append(args, meth)
 	}
-	fmts += " err=%s;"
 	if ctype != nil {
 		fmts += " ctype=%s;"
+		args = append(args, ctype)
 	}
+
+	fmts += " err=%s;"
 	var es string
 	if err == nil {
 		es = "null"

--- a/rpc/log.go
+++ b/rpc/log.go
@@ -21,6 +21,9 @@ type LogInterface interface {
 	ClientCall(SeqNumber, string, interface{})
 	ServerCall(SeqNumber, string, error, interface{})
 	ServerReply(SeqNumber, string, error, interface{})
+	ClientCallCompressed(SeqNumber, string, interface{}, CompressionType)
+	ServerCallCompressed(SeqNumber, string, error, interface{}, CompressionType)
+	ServerReplyCompressed(SeqNumber, string, error, interface{}, CompressionType)
 	ClientNotify(string, interface{})
 	ServerNotifyCall(string, error, interface{})
 	ServerNotifyComplete(string, error)
@@ -195,56 +198,74 @@ func (s SimpleLog) FrameRead(bytes []byte) {
 // Call
 func (s SimpleLog) ClientCall(q SeqNumber, meth string, arg interface{}) {
 	if s.Opts.ClientTrace() {
-		s.trace("call", "arg", s.Opts.ShowArg(), q, meth, nil, arg)
+		s.trace("call", "arg", s.Opts.ShowArg(), q, meth, nil, arg, nil)
 	}
 }
 func (s SimpleLog) ServerCall(q SeqNumber, meth string, err error, arg interface{}) {
 	if s.Opts.ServerTrace() {
-		s.trace("serve", "arg", s.Opts.ShowArg(), q, meth, err, arg)
+		s.trace("serve", "arg", s.Opts.ShowArg(), q, meth, err, arg, nil)
 	}
 }
 func (s SimpleLog) ServerReply(q SeqNumber, meth string, err error, res interface{}) {
 	if s.Opts.ServerTrace() {
-		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res)
+		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res, nil)
+	}
+}
+
+// CallCompressed
+func (s SimpleLog) ClientCallCompressed(q SeqNumber, meth string, arg interface{}, ctype CompressionType) {
+	if s.Opts.ClientTrace() {
+		s.trace("call-compressed", "arg", s.Opts.ShowArg(), q, meth, nil, arg, &ctype)
+	}
+}
+func (s SimpleLog) ServerCallCompressed(q SeqNumber, meth string, err error, arg interface{}, ctype CompressionType) {
+	if s.Opts.ServerTrace() {
+		s.trace("serve-compressed", "arg", s.Opts.ShowArg(), q, meth, err, arg, &ctype)
+	}
+}
+func (s SimpleLog) ServerReplyCompressed(q SeqNumber, meth string, err error, res interface{}, ctype CompressionType) {
+	if s.Opts.ServerTrace() {
+		s.trace("reply-compressed", "res", s.Opts.ShowResult(), q, meth, err, res, &ctype)
 	}
 }
 
 // Notify
 func (s SimpleLog) ClientNotify(meth string, arg interface{}) {
 	if s.Opts.ClientTrace() {
-		s.trace("notify", "arg", s.Opts.ShowArg(), 0, meth, nil, arg)
+		s.trace("notify", "arg", s.Opts.ShowArg(), 0, meth, nil, arg, nil)
 	}
 }
 func (s SimpleLog) ServerNotifyCall(meth string, err error, arg interface{}) {
 	if s.Opts.ServerTrace() {
-		s.trace("serve-notify", "arg", s.Opts.ShowArg(), 0, meth, err, arg)
+		s.trace("serve-notify", "arg", s.Opts.ShowArg(), 0, meth, err, arg, nil)
 	}
 }
 func (s SimpleLog) ServerNotifyComplete(meth string, err error) {
 	if s.Opts.ServerTrace() {
-		s.trace("complete", "", false, 0, meth, err, nil)
+		s.trace("complete", "", false, 0, meth, err, nil, nil)
 	}
 }
 
 // Cancel
 func (s SimpleLog) ClientCancel(q SeqNumber, meth string, err error) {
 	if s.Opts.ClientTrace() {
-		s.trace("cancel", "", false, q, meth, err, nil)
+		s.trace("cancel", "", false, q, meth, err, nil, nil)
 	}
 }
 func (s SimpleLog) ServerCancelCall(q SeqNumber, meth string) {
 	if s.Opts.ServerTrace() {
-		s.trace("serve-cancel", "", false, q, meth, nil, nil)
+		s.trace("serve-cancel", "", false, q, meth, nil, nil, nil)
 	}
 }
 
 func (s SimpleLog) ClientReply(q SeqNumber, meth string, err error, res interface{}) {
 	if s.Opts.ClientTrace() {
-		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res)
+		s.trace("reply", "res", s.Opts.ShowResult(), q, meth, err, res, nil)
 	}
 }
 
-func (s SimpleLog) trace(which string, objname string, verbose bool, q SeqNumber, meth string, err error, obj interface{}) {
+func (s SimpleLog) trace(which string, objname string, verbose bool, q SeqNumber,
+	meth string, err error, obj interface{}, ctype *CompressionType) {
 	args := []interface{}{which, q}
 	fmts := "%s(%d):"
 	if len(meth) > 0 {
@@ -252,6 +273,9 @@ func (s SimpleLog) trace(which string, objname string, verbose bool, q SeqNumber
 		args = append(args, meth)
 	}
 	fmts += " err=%s;"
+	if ctype != nil {
+		fmts += " ctype=%s;"
+	}
 	var es string
 	if err == nil {
 		es = "null"

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -20,24 +20,24 @@ func createMessageTestProtocol() *protocolHandler {
 				Handler: func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	})
 	return p
 }
 
-func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
+func runMessageTest(t *testing.T, ctype CompressionType, v []interface{}) (rpcMessage, error) {
 	var buf bytes.Buffer
 	enc := newFramedMsgpackEncoder(testMaxFrameLength, &buf)
 	cc := newCallContainer()
-	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), nil)
+	c := cc.NewCall(context.Background(), "foo.bar", new(interface{}), new(string), CompressionNone, nil)
 	cc.AddCall(c)
 
 	log := newTestLog(t)
 	pkt := newPacketizer(testMaxFrameLength, &buf, createMessageTestProtocol(), cc, log)
 
-	err := <-enc.EncodeAndWrite(c.ctx, v, nil)
+	err := <-enc.EncodeAndWrite(c.ctx, ctype, v, nil)
 	require.NoError(t, err, "expected encoding to succeed")
 
 	return pkt.NextFrame()
@@ -46,11 +46,26 @@ func runMessageTest(t *testing.T, v []interface{}) (rpcMessage, error) {
 func TestMessageDecodeValid(t *testing.T) {
 	v := []interface{}{MethodCall, 999, "abc.hello", new(interface{})}
 
-	rpc, err := runMessageTest(t, v)
+	rpc, err := runMessageTest(t, CompressionNone, v)
 	require.NoError(t, err)
 	c, ok := rpc.(*rpcCallMessage)
 	require.True(t, ok)
 	require.Equal(t, MethodCall, c.Type())
+	require.Equal(t, CompressionNone, c.Compression())
+	require.Equal(t, SeqNumber(999), c.SeqNo())
+	require.Equal(t, "abc.hello", c.Name())
+	require.Equal(t, nil, c.Arg())
+}
+
+func TestMessageDecodeValidCompressed(t *testing.T) {
+	v := []interface{}{MethodCallCompressed, 999, CompressionGzip, "abc.hello", new(interface{})}
+
+	rpc, err := runMessageTest(t, CompressionGzip, v)
+	require.NoError(t, err)
+	c, ok := rpc.(*rpcCallCompressedMessage)
+	require.True(t, ok)
+	require.Equal(t, MethodCallCompressed, c.Type())
+	require.Equal(t, CompressionGzip, c.Compression())
 	require.Equal(t, SeqNumber(999), c.SeqNo())
 	require.Equal(t, "abc.hello", c.Name())
 	require.Equal(t, nil, c.Arg())
@@ -60,12 +75,13 @@ func TestMessageDecodeValidExtraParams(t *testing.T) {
 	tags := CtxRpcTags{"hello": "world"}
 	v := []interface{}{MethodCall, 999, "abc.hello", new(interface{}), tags, "foo"}
 
-	rpc, err := runMessageTest(t, v)
+	rpc, err := runMessageTest(t, CompressionNone, v)
 	require.NoError(t, err)
 	c, ok := rpc.(*rpcCallMessage)
 	require.True(t, ok)
 	require.Equal(t, MethodCall, c.Type())
 	require.Equal(t, SeqNumber(999), c.SeqNo())
+	require.Equal(t, CompressionNone, c.Compression())
 	require.Equal(t, "abc.hello", c.Name())
 	require.Equal(t, nil, c.Arg())
 	resultTags, ok := RpcTagsFromContext(c.Context())
@@ -76,13 +92,14 @@ func TestMessageDecodeValidExtraParams(t *testing.T) {
 func TestMessageDecodeValidResponse(t *testing.T) {
 	v := []interface{}{MethodResponse, SeqNumber(0), nil, "hi"}
 
-	rpc, err := runMessageTest(t, v)
+	rpc, err := runMessageTest(t, CompressionNone, v)
 	require.NoError(t, err)
-	r, ok := rpc.(*rpcResponseMessage)
+	c, ok := rpc.(*rpcResponseMessage)
 	require.True(t, ok)
-	require.Equal(t, MethodResponse, r.Type())
-	require.Equal(t, SeqNumber(0), r.SeqNo())
-	resAsString, ok := r.Res().(*string)
+	require.Equal(t, MethodResponse, c.Type())
+	require.Equal(t, CompressionNone, c.Compression())
+	require.Equal(t, SeqNumber(0), c.SeqNo())
+	resAsString, ok := c.Res().(*string)
 	require.True(t, ok)
 	require.Equal(t, "hi", *resAsString)
 	require.True(t, ok)
@@ -91,7 +108,7 @@ func TestMessageDecodeValidResponse(t *testing.T) {
 func TestMessageDecodeInvalidType(t *testing.T) {
 	v := []interface{}{"hello", SeqNumber(0), "invalid", new(interface{})}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "RPC error. type: Invalid, method: , length: 4, error: error decoding message field at position 0, error: ")
 }
@@ -99,34 +116,34 @@ func TestMessageDecodeInvalidType(t *testing.T) {
 func TestMessageDecodeInvalidMethodType(t *testing.T) {
 	v := []interface{}{MethodType(999), SeqNumber(0), "invalid", new(interface{})}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.EqualError(t, err, "RPC error. type: Method(999), method: , length: 4, error: invalid RPC type")
 }
 
 func TestMessageDecodeInvalidProtocol(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "nonexistent.broken", new(interface{})}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.EqualError(t, err, "RPC error. type: Call, method: nonexistent.broken, length: 4, error: protocol not found: nonexistent")
 }
 
 func TestMessageDecodeInvalidMethod(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid", new(interface{})}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.EqualError(t, err, "RPC error. type: Call, method: abc.invalid, length: 4, error: method 'invalid' not found in protocol 'abc'")
 }
 
 func TestMessageDecodeWrongMessageLength(t *testing.T) {
 	v := []interface{}{MethodCall, SeqNumber(0), "abc.invalid"}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.EqualError(t, err, "RPC error. type: Call, method: , length: 3, error: wrong message length")
 }
 
 func TestMessageDecodeResponseNilCall(t *testing.T) {
 	v := []interface{}{MethodResponse, SeqNumber(-1), 32, "hi"}
 
-	_, err := runMessageTest(t, v)
+	_, err := runMessageTest(t, CompressionNone, v)
 	require.EqualError(t, err, "RPC error. type: Response, method: , length: 4, error: Call not found for sequence number -1")
 }

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -37,7 +37,7 @@ func runMessageTest(t *testing.T, ctype CompressionType, v []interface{}) (rpcMe
 	log := newTestLog(t)
 	pkt := newPacketizer(testMaxFrameLength, &buf, createMessageTestProtocol(), cc, log)
 
-	err := <-enc.EncodeAndWrite(c.ctx, ctype, v, nil)
+	err := <-enc.EncodeAndWrite(c.ctx, v, nil)
 	require.NoError(t, err, "expected encoding to succeed")
 
 	return pkt.NextFrame()

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -20,7 +20,6 @@ func createMessageTestProtocol() *protocolHandler {
 				Handler: func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	})

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -121,7 +121,6 @@ func createPacketizerTestProtocol() *protocolHandler {
 				Handler: func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	})

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -121,7 +121,7 @@ func createPacketizerTestProtocol() *protocolHandler {
 				Handler: func(context.Context, interface{}) (interface{}, error) {
 					return nil, nil
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	})
@@ -202,12 +202,12 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	enc := newFramedMsgpackEncoder(testMaxFrameLength, &buf)
 	ctx := context.Background()
 	for _, frame := range frames {
-		err := <-enc.encodeAndWriteInternal(ctx, frame, nil)
+		err := <-enc.encodeAndWriteInternal(ctx, CompressionNone, frame, nil)
 		require.NoError(t, err)
 	}
 
 	cc := newCallContainer()
-	c := cc.NewCall(ctx, "foo.bar", new(interface{}), new(string), nil)
+	c := cc.NewCall(ctx, "foo.bar", new(interface{}), new(string), CompressionNone, nil)
 	cc.AddCall(c)
 
 	log := newTestLog(t)

--- a/rpc/packetizer_test.go
+++ b/rpc/packetizer_test.go
@@ -202,7 +202,7 @@ func TestPacketizerDecodeInvalidFrames(t *testing.T) {
 	enc := newFramedMsgpackEncoder(testMaxFrameLength, &buf)
 	ctx := context.Background()
 	for _, frame := range frames {
-		err := <-enc.encodeAndWriteInternal(ctx, CompressionNone, frame, nil)
+		err := <-enc.encodeAndWriteInternal(ctx, frame, nil)
 		require.NoError(t, err)
 	}
 

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -16,13 +16,12 @@ type ServeHandlerDescription struct {
 type MethodType int
 
 const (
-	MethodInvalid            MethodType = -1
-	MethodCall               MethodType = 0
-	MethodResponse           MethodType = 1
-	MethodNotify             MethodType = 2
-	MethodCancel             MethodType = 3
-	MethodCallCompressed     MethodType = 4
-	MethodResponseCompressed MethodType = 5
+	MethodInvalid        MethodType = -1
+	MethodCall           MethodType = 0
+	MethodResponse       MethodType = 1
+	MethodNotify         MethodType = 2
+	MethodCancel         MethodType = 3
+	MethodCallCompressed MethodType = 4
 )
 
 func (t MethodType) String() string {
@@ -39,8 +38,6 @@ func (t MethodType) String() string {
 		return "Cancel"
 	case MethodCallCompressed:
 		return "CallCompressed"
-	case MethodResponseCompressed:
-		return "ResponseCompressed"
 	default:
 		return fmt.Sprintf("Method(%d)", t)
 	}
@@ -61,6 +58,15 @@ func (t CompressionType) String() string {
 		return "gzip"
 	default:
 		return fmt.Sprintf("Compression(%d)", t)
+	}
+}
+
+func (t CompressionType) NewCompressor() compressor {
+	switch t {
+	case CompressionGzip:
+		return newGzipCompressor()
+	default:
+		return nil
 	}
 }
 

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -8,19 +8,21 @@ import (
 )
 
 type ServeHandlerDescription struct {
-	MakeArg    func() interface{}
-	Handler    func(ctx context.Context, arg interface{}) (ret interface{}, err error)
-	MethodType MethodType
+	MakeArg     func() interface{}
+	Handler     func(ctx context.Context, arg interface{}) (ret interface{}, err error)
+	MethodTypes []MethodType
 }
 
 type MethodType int
 
 const (
-	MethodInvalid  MethodType = -1
-	MethodCall     MethodType = 0
-	MethodResponse MethodType = 1
-	MethodNotify   MethodType = 2
-	MethodCancel   MethodType = 3
+	MethodInvalid            MethodType = -1
+	MethodCall               MethodType = 0
+	MethodResponse           MethodType = 1
+	MethodNotify             MethodType = 2
+	MethodCancel             MethodType = 3
+	MethodCallCompressed     MethodType = 4
+	MethodResponseCompressed MethodType = 5
 )
 
 func (t MethodType) String() string {
@@ -35,8 +37,30 @@ func (t MethodType) String() string {
 		return "Notify"
 	case MethodCancel:
 		return "Cancel"
+	case MethodCallCompressed:
+		return "CallCompressed"
+	case MethodResponseCompressed:
+		return "ResponseCompressed"
 	default:
 		return fmt.Sprintf("Method(%d)", t)
+	}
+}
+
+type CompressionType int
+
+const (
+	CompressionNone CompressionType = 0
+	CompressionGzip CompressionType = 1
+)
+
+func (t CompressionType) String() string {
+	switch t {
+	case CompressionNone:
+		return "none"
+	case CompressionGzip:
+		return "gzip"
+	default:
+		return fmt.Sprintf("Compression(%d)", t)
 	}
 }
 

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -8,9 +8,8 @@ import (
 )
 
 type ServeHandlerDescription struct {
-	MakeArg     func() interface{}
-	Handler     func(ctx context.Context, arg interface{}) (ret interface{}, err error)
-	MethodTypes []MethodType
+	MakeArg func() interface{}
+	Handler func(ctx context.Context, arg interface{}) (ret interface{}, err error)
 }
 
 type MethodType int

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -115,6 +115,40 @@ func TestLongCall(t *testing.T) {
 	require.Equal(t, longResult, 100, "call should have succeeded")
 }
 
+func TestCallCompressed(t *testing.T) {
+	cli, listener, conn := prepTest(t)
+	defer endTest(t, conn, listener)
+
+	pi := 31415
+	constants := Constants{Pi: pi}
+	err := cli.UpdateConstants(context.Background(), constants)
+	require.NoError(t, err, "Unexpected error on notify: %v", err)
+
+	nargs := NArgs{N: 50}
+	verifyRes := func(res []*Constants, err error) {
+		require.NoError(t, err, "call should have succeeded")
+		require.Len(t, res, nargs.N)
+		for i := 0; i < nargs.N; i++ {
+			require.NotNil(t, res[i])
+			require.Equal(t, constants, *res[i])
+		}
+	}
+
+	// Try normal CLI (CallCompressed w/CompressionGzip)
+	ctx := context.Background()
+	res, err := cli.GetNConstants(ctx, nargs)
+	verifyRes(res, err)
+
+	// Also test CallCompressed w/CompressionNone and regular Call work identically
+	res = []*Constants{}
+	err = cli.CallCompressed(ctx, "test.1.testp.GetNConstants", nargs, &res, CompressionNone)
+	verifyRes(res, err)
+
+	res = []*Constants{}
+	err = cli.Call(ctx, "test.1.testp.GetNConstants", nargs, &res)
+	verifyRes(res, err)
+}
+
 func TestLongCallCancel(t *testing.T) {
 	cli, listener, conn := prepTest(t)
 	defer endTest(t, conn, listener)

--- a/rpc/protocol_test.go
+++ b/rpc/protocol_test.go
@@ -119,10 +119,7 @@ func TestCallCompressed(t *testing.T) {
 	cli, listener, conn := prepTest(t)
 	defer endTest(t, conn, listener)
 
-	pi := 31415
-	constants := Constants{Pi: pi}
-	err := cli.UpdateConstants(context.Background(), constants)
-	require.NoError(t, err, "Unexpected error on notify: %v", err)
+	ctx := context.Background()
 
 	nargs := NArgs{N: 50}
 	verifyRes := func(res []*Constants, err error) {
@@ -130,12 +127,11 @@ func TestCallCompressed(t *testing.T) {
 		require.Len(t, res, nargs.N)
 		for i := 0; i < nargs.N; i++ {
 			require.NotNil(t, res[i])
-			require.Equal(t, constants, *res[i])
+			require.Equal(t, Constants{}, *res[i])
 		}
 	}
 
 	// Try normal CLI (CallCompressed w/CompressionGzip)
-	ctx := context.Background()
 	res, err := cli.GetNConstants(ctx, nargs)
 	verifyRes(res, err)
 

--- a/rpc/protocol_utils_test.go
+++ b/rpc/protocol_utils_test.go
@@ -140,7 +140,7 @@ func createTestProtocol(i TestInterface) Protocol {
 					}
 					return i.Add(addArgs)
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"GetConstants": {
 				MakeArg: func() interface{} {
@@ -149,7 +149,7 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(_ context.Context, _ interface{}) (interface{}, error) {
 					return i.GetConstants()
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"updateConstants": {
 				MakeArg: func() interface{} {
@@ -163,7 +163,7 @@ func createTestProtocol(i TestInterface) Protocol {
 					err := i.UpdateConstants(constants)
 					return nil, err
 				},
-				MethodType: MethodNotify,
+				MethodTypes: []MethodType{MethodNotify},
 			},
 			"LongCall": {
 				MakeArg: func() interface{} {
@@ -172,7 +172,7 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCall(ctx)
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"LongCallResult": {
 				MakeArg: func() interface{} {
@@ -181,7 +181,7 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCallResult(ctx)
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"LongCallDebugTags": {
 				MakeArg: func() interface{} {
@@ -190,7 +190,7 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCallDebugTags(ctx)
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	}

--- a/rpc/protocol_utils_test.go
+++ b/rpc/protocol_utils_test.go
@@ -155,7 +155,6 @@ func createTestProtocol(i TestInterface) Protocol {
 					}
 					return i.Add(addArgs)
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"GetConstants": {
 				MakeArg: func() interface{} {
@@ -164,7 +163,6 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(_ context.Context, _ interface{}) (interface{}, error) {
 					return i.GetConstants()
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"GetNConstants": {
 				MakeArg: func() interface{} {
@@ -177,7 +175,6 @@ func createTestProtocol(i TestInterface) Protocol {
 					}
 					return i.GetNConstants(nargs)
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"updateConstants": {
 				MakeArg: func() interface{} {
@@ -191,7 +188,6 @@ func createTestProtocol(i TestInterface) Protocol {
 					err := i.UpdateConstants(constants)
 					return nil, err
 				},
-				MethodTypes: []MethodType{MethodNotify},
 			},
 			"LongCall": {
 				MakeArg: func() interface{} {
@@ -200,7 +196,6 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCall(ctx)
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"LongCallResult": {
 				MakeArg: func() interface{} {
@@ -209,7 +204,6 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCallResult(ctx)
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 			"LongCallDebugTags": {
 				MakeArg: func() interface{} {
@@ -218,7 +212,6 @@ func createTestProtocol(i TestInterface) Protocol {
 				Handler: func(ctx context.Context, _ interface{}) (interface{}, error) {
 					return i.LongCallDebugTags(ctx)
 				},
-				MethodTypes: []MethodType{MethodCall, MethodCallCompressed},
 			},
 		},
 	}

--- a/rpc/receiver.go
+++ b/rpc/receiver.go
@@ -85,6 +85,8 @@ func (r *receiveHandler) Receive(rpc rpcMessage) error {
 		return r.receiveResponse(message)
 	case *rpcCancelMessage:
 		return r.receiveCancel(message)
+	case *rpcCallCompressedMessage:
+		return r.receiveCallCompressed(message)
 	default:
 		return NewReceiverError("invalid message type, %d", rpc.Type())
 	}
@@ -97,6 +99,11 @@ func (r *receiveHandler) receiveNotify(rpc *rpcNotifyMessage) error {
 
 func (r *receiveHandler) receiveCall(rpc *rpcCallMessage) error {
 	req := newCallRequest(rpc, r.log)
+	return r.handleReceiveDispatch(req)
+}
+
+func (r *receiveHandler) receiveCallCompressed(rpc *rpcCallCompressedMessage) error {
+	req := newCallCompressedRequest(rpc, r.log)
 	return r.handleReceiveDispatch(req)
 }
 

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -101,7 +101,7 @@ func TestCloseReceiver(t *testing.T) {
 					waitCh <- c.Err()
 					return nil, c.Err()
 				},
-				MethodType: MethodCall,
+				MethodTypes: []MethodType{MethodCall},
 			},
 		},
 	}

--- a/rpc/receiver_test.go
+++ b/rpc/receiver_test.go
@@ -101,7 +101,6 @@ func TestCloseReceiver(t *testing.T) {
 					waitCh <- c.Err()
 					return nil, c.Err()
 				},
-				MethodTypes: []MethodType{MethodCall},
 			},
 		},
 	}

--- a/rpc/request.go
+++ b/rpc/request.go
@@ -55,7 +55,7 @@ func (r *callRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg i
 		errArg,
 		res,
 	}
-	errCh := enc.EncodeAndWrite(r.ctx, v, nil)
+	errCh := enc.EncodeAndWrite(r.ctx, r.Compression(), v, nil)
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -70,6 +70,63 @@ func (r *callRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg i
 func (r *callRequest) Serve(transmitter *framedMsgpackEncoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
 
 	prof := r.log.StartProfiler("serve %s", r.Name())
+	arg := r.Arg()
+
+	r.LogInvocation(nil)
+	res, err := handler.Handler(r.ctx, arg)
+	prof.Stop()
+	r.LogCompletion(res, err)
+
+	r.Reply(transmitter, res, wrapError(wrapErrorFunc, err))
+}
+
+type callCompressedRequest struct {
+	*rpcCallCompressedMessage
+	requestImpl
+}
+
+func newCallCompressedRequest(rpc *rpcCallCompressedMessage, log LogInterface) *callCompressedRequest {
+	ctx, cancel := context.WithCancel(rpc.Context())
+	return &callCompressedRequest{
+		rpcCallCompressedMessage: rpc,
+		requestImpl: requestImpl{
+			ctx:        ctx,
+			cancelFunc: cancel,
+			log:        log,
+		},
+	}
+}
+
+func (r *callCompressedRequest) LogInvocation(err error) {
+	r.log.ServerCallCompressed(r.SeqNo(), r.Name(), err, r.Arg(), r.Compression())
+}
+
+func (r *callCompressedRequest) LogCompletion(res interface{}, err error) {
+	r.log.ServerReplyCompressed(r.SeqNo(), r.Name(), err, res, r.Compression())
+}
+
+func (r *callCompressedRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg interface{}) (err error) {
+	v := []interface{}{
+		MethodResponse,
+		r.SeqNo(),
+		errArg,
+		res,
+	}
+	errCh := enc.EncodeAndWrite(r.ctx, r.Compression(), v, nil)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			r.log.Warning("Reply error for %d: %s", r.SeqNo(), err.Error())
+		}
+	case <-r.ctx.Done():
+		r.log.Info("Call canceled after reply sent. Seq: %d", r.SeqNo())
+	}
+	return err
+}
+
+func (r *callCompressedRequest) Serve(transmitter *framedMsgpackEncoder, handler *ServeHandlerDescription, wrapErrorFunc WrapErrorFunc) {
+
+	prof := r.log.StartProfiler("serve-compressed %s", r.Name())
 	arg := r.Arg()
 
 	r.LogInvocation(nil)

--- a/rpc/request.go
+++ b/rpc/request.go
@@ -55,7 +55,7 @@ func (r *callRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg i
 		errArg,
 		res,
 	}
-	errCh := enc.EncodeAndWrite(r.ctx, r.Compression(), v, nil)
+	errCh := enc.EncodeAndWrite(r.ctx, v, nil)
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -106,13 +106,17 @@ func (r *callCompressedRequest) LogCompletion(res interface{}, err error) {
 }
 
 func (r *callCompressedRequest) Reply(enc *framedMsgpackEncoder, res interface{}, errArg interface{}) (err error) {
+	res, err = enc.compressResponse(r.Compression(), res)
+	if err != nil {
+		return err
+	}
 	v := []interface{}{
 		MethodResponse,
 		r.SeqNo(),
 		errArg,
 		res,
 	}
-	errCh := enc.EncodeAndWrite(r.ctx, r.Compression(), v, nil)
+	errCh := enc.EncodeAndWrite(r.ctx, v, nil)
 	select {
 	case err := <-errCh:
 		if err != nil {


### PR DESCRIPTION
Initial stab at compressing RPC responses. Patch does the following:

- introduces a new call type `CallCompressed` which takes a `CompressionType` to specify how the RPC response should be compressed. Only `CompressionGzip` is implemented
- `CallCompressed` exists for backwards compatibility since we have to send the `CompressionType` in the server but can supersede `Call` entirely by passing `CompressionNone`
- When receiving a `CallCompressed` request the `CompressionType` is decoded and the applicable compression algorithm is applied to the RPC response
- `CallCompressed` replies with a normal `rpcResponseMessage` and upon retrieving the `call` info, knows if decompression is necessary
- `ServeHandlerDescription`  now accepts an array of methods so `MethodCall` and `MethodCallCompressed` can be present. It seems this field is entirely ignored within the library, what was the original intention?