### PR TITLE
Add msgpackzip compression type

### DIFF
--- a/rpc/compress_gzip.go
+++ b/rpc/compress_gzip.go
@@ -1,0 +1,80 @@
+package rpc
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"io/ioutil"
+	"sync"
+)
+
+var gzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		return gzip.NewWriter(ioutil.Discard)
+	},
+}
+
+var gzipReaderPool = sync.Pool{
+	New: func() interface{} {
+		return new(gzip.Reader)
+	},
+}
+
+type gzipCompressor struct{}
+
+var _ compressor = (*gzipCompressor)(nil)
+
+func newGzipCompressor() *gzipCompressor {
+	return &gzipCompressor{}
+}
+
+func (c *gzipCompressor) getGzipWriter(writer io.Writer) (*gzip.Writer, func()) {
+	gzipWriter := gzipWriterPool.Get().(*gzip.Writer)
+	gzipWriter.Reset(writer)
+	return gzipWriter, func() {
+		gzipWriterPool.Put(gzipWriter)
+	}
+}
+func (c *gzipCompressor) getGzipReader(reader io.Reader) (*gzip.Reader, func(), error) {
+	gzipReader := gzipReaderPool.Get().(*gzip.Reader)
+	if err := gzipReader.Reset(reader); err != nil {
+		return nil, func() {}, err
+	}
+	return gzipReader, func() {
+		gzipReaderPool.Put(gzipReader)
+	}, nil
+}
+
+func (c *gzipCompressor) Compress(data []byte) ([]byte, error) {
+
+	var buf bytes.Buffer
+	writer, reclaim := c.getGzipWriter(&buf)
+	defer reclaim()
+
+	if _, err := writer.Write(data); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *gzipCompressor) Decompress(data []byte) ([]byte, error) {
+
+	in := bytes.NewReader(data)
+	reader, reclaim, err := c.getGzipReader(in)
+	if err != nil {
+		return nil, err
+	}
+	defer reclaim()
+
+	var out bytes.Buffer
+	if _, err := out.ReadFrom(reader); err != nil {
+		return nil, err
+	}
+	if err := reader.Close(); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}

--- a/rpc/compress_msgpackzip.go
+++ b/rpc/compress_msgpackzip.go
@@ -1,0 +1,19 @@
+package rpc
+
+import "github.com/keybase/msgpackzip"
+
+type msgpackzipCompressor struct{}
+
+var _ compressor = (*msgpackzipCompressor)(nil)
+
+func newMsgpackzipCompressor() *msgpackzipCompressor {
+	return &msgpackzipCompressor{}
+}
+
+func (c *msgpackzipCompressor) Compress(data []byte) ([]byte, error) {
+	return msgpackzip.Compress(data)
+}
+
+func (c *msgpackzipCompressor) Decompress(data []byte) ([]byte, error) {
+	return msgpackzip.Inflate(data)
+}

--- a/rpc/compressor.go
+++ b/rpc/compressor.go
@@ -1,87 +1,12 @@
 package rpc
 
 import (
-	"bytes"
-	"compress/gzip"
-	"io"
-	"io/ioutil"
 	"sync"
 )
 
 type compressor interface {
 	Compress([]byte) ([]byte, error)
 	Decompress([]byte) ([]byte, error)
-}
-
-var gzipWriterPool = sync.Pool{
-	New: func() interface{} {
-		return gzip.NewWriter(ioutil.Discard)
-	},
-}
-
-var gzipReaderPool = sync.Pool{
-	New: func() interface{} {
-		return new(gzip.Reader)
-	},
-}
-
-type gzipCompressor struct{}
-
-var _ compressor = (*gzipCompressor)(nil)
-
-func newGzipCompressor() *gzipCompressor {
-	return &gzipCompressor{}
-}
-
-func (c *gzipCompressor) getGzipWriter(writer io.Writer) (*gzip.Writer, func()) {
-	gzipWriter := gzipWriterPool.Get().(*gzip.Writer)
-	gzipWriter.Reset(writer)
-	return gzipWriter, func() {
-		gzipWriterPool.Put(gzipWriter)
-	}
-}
-func (c *gzipCompressor) getGzipReader(reader io.Reader) (*gzip.Reader, func(), error) {
-	gzipReader := gzipReaderPool.Get().(*gzip.Reader)
-	if err := gzipReader.Reset(reader); err != nil {
-		return nil, func() {}, err
-	}
-	return gzipReader, func() {
-		gzipReaderPool.Put(gzipReader)
-	}, nil
-}
-
-func (c *gzipCompressor) Compress(data []byte) ([]byte, error) {
-
-	var buf bytes.Buffer
-	writer, reclaim := c.getGzipWriter(&buf)
-	defer reclaim()
-
-	if _, err := writer.Write(data); err != nil {
-		return nil, err
-	}
-	if err := writer.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (c *gzipCompressor) Decompress(data []byte) ([]byte, error) {
-
-	in := bytes.NewReader(data)
-	reader, reclaim, err := c.getGzipReader(in)
-	if err != nil {
-		return nil, err
-	}
-	defer reclaim()
-
-	var out bytes.Buffer
-	if _, err := out.ReadFrom(reader); err != nil {
-		return nil, err
-	}
-	if err := reader.Close(); err != nil {
-		return nil, err
-	}
-	return out.Bytes(), nil
 }
 
 type compressorCacher struct {

--- a/rpc/compressor_test.go
+++ b/rpc/compressor_test.go
@@ -3,36 +3,59 @@ package rpc
 import (
 	"testing"
 
+	"github.com/keybase/go-codec/codec"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGzip(t *testing.T) {
-	c := newCompressorCacher()
+func MPackEncode(input interface{}) ([]byte, error) {
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, &mh)
+	if err := enc.Encode(input); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
 
-	// Make sure we don't make multiple instances of compressors
-	gz := c.getCompressor(CompressionGzip)
-	c.getCompressor(CompressionGzip)
-	none := c.getCompressor(CompressionNone)
-	require.Nil(t, none)
-	require.Len(t, c.algs, 2)
+type testData struct {
+	Data []byte `codec:"data"`
+}
 
-	data := []byte("gzip me")
-	zipped, err := gz.Compress(data)
-	require.NoError(t, err)
+func doWithAllCompressionTypes(fn func(ctype CompressionType)) {
+	for _, ctype := range []CompressionType{CompressionGzip, CompressionMsgpackzip} {
+		fn(ctype)
+	}
+}
 
-	unzipped, err := gz.Decompress(zipped)
-	require.NoError(t, err)
-	require.Equal(t, data, unzipped)
+func TestCompressionAlgs(t *testing.T) {
+	doWithAllCompressionTypes(func(ctype CompressionType) {
+		c := newCompressorCacher()
 
-	garbage, err := gz.Decompress(data)
-	require.Error(t, err)
-	require.Nil(t, garbage)
+		// Make sure we don't make multiple instances of compressors
+		compressor := c.getCompressor(ctype)
+		c.getCompressor(ctype)
+		none := c.getCompressor(CompressionNone)
+		require.Nil(t, none)
+		require.Len(t, c.algs, 2)
 
-	// compress/decompress again to test reader/writer reuse
-	zipped2, err := gz.Compress(data)
-	require.NoError(t, err)
-	unzipped2, err := gz.Decompress(zipped2)
-	require.NoError(t, err)
-	require.Equal(t, data, unzipped2)
-	require.Equal(t, unzipped, unzipped2)
+		data, err := MPackEncode(testData{Data: []byte("compress me")})
+		require.NoError(t, err)
+		zipped, err := compressor.Compress(data)
+		require.NoError(t, err)
+
+		unzipped, err := compressor.Decompress(zipped)
+		require.NoError(t, err)
+		require.Equal(t, data, unzipped)
+
+		garbage, err := compressor.Decompress(data)
+		require.Error(t, err)
+		require.Nil(t, garbage)
+
+		zipped2, err := compressor.Compress(data)
+		require.NoError(t, err)
+		unzipped2, err := compressor.Decompress(zipped2)
+		require.NoError(t, err)
+		require.Equal(t, data, unzipped2)
+		require.Equal(t, unzipped, unzipped2)
+	})
 }

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -257,17 +257,19 @@ func TestConnectionClientCallError(t *testing.T) {
 }
 
 func TestConnectionClientCallCompressedError(t *testing.T) {
-	serverConn, conn := MakeConnectionForTest(t)
-	defer conn.Shutdown()
+	doWithAllCompressionTypes(func(ctype CompressionType) {
+		serverConn, conn := MakeConnectionForTest(t)
+		defer conn.Shutdown()
 
-	c := connectionClient{conn}
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- c.CallCompressed(context.Background(), "callRpc", nil, nil, CompressionGzip)
-	}()
-	serverConn.Close()
-	err := <-errCh
-	require.Error(t, err)
+		c := connectionClient{conn}
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- c.CallCompressed(context.Background(), "callRpc", nil, nil, ctype)
+		}()
+		serverConn.Close()
+		err := <-errCh
+		require.Error(t, err)
+	})
 }
 
 func TestConnectionClientNotifyError(t *testing.T) {

--- a/rpc/dispatch_test.go
+++ b/rpc/dispatch_test.go
@@ -60,18 +60,19 @@ func TestDispatchSuccessfulCall(t *testing.T) {
 }
 
 func TestDispatchSuccessfulCallCompressed(t *testing.T) {
-	ctype := CompressionGzip
-	d, calls, done := dispatchTestCallWithContextAndCompressionType(t, context.Background(), ctype)
+	doWithAllCompressionTypes(func(ctype CompressionType) {
+		d, calls, done := dispatchTestCallWithContextAndCompressionType(t, context.Background(), ctype)
 
-	c := calls.RetrieveCall(0)
-	require.NotNil(t, c, "Expected c not to be nil")
-	require.Equal(t, ctype, c.ctype)
+		c := calls.RetrieveCall(0)
+		require.NotNil(t, c, "Expected c not to be nil")
+		require.Equal(t, ctype, c.ctype)
 
-	sendResponse(c, nil)
-	err := <-done
-	require.NoError(t, err, "Expected no error")
+		sendResponse(c, nil)
+		err := <-done
+		require.NoError(t, err, "Expected no error")
 
-	d.Close()
+		d.Close()
+	})
 }
 
 func TestDispatchCanceledBeforeResult(t *testing.T) {

--- a/rpc/message_test.go
+++ b/rpc/message_test.go
@@ -57,17 +57,19 @@ func TestMessageDecodeValid(t *testing.T) {
 }
 
 func TestMessageDecodeValidCompressed(t *testing.T) {
-	v := []interface{}{MethodCallCompressed, 999, CompressionGzip, "abc.hello", new(interface{})}
+	doWithAllCompressionTypes(func(ctype CompressionType) {
+		v := []interface{}{MethodCallCompressed, 999, ctype, "abc.hello", new(interface{})}
 
-	rpc, err := runMessageTest(t, CompressionGzip, v)
-	require.NoError(t, err)
-	c, ok := rpc.(*rpcCallCompressedMessage)
-	require.True(t, ok)
-	require.Equal(t, MethodCallCompressed, c.Type())
-	require.Equal(t, CompressionGzip, c.Compression())
-	require.Equal(t, SeqNumber(999), c.SeqNo())
-	require.Equal(t, "abc.hello", c.Name())
-	require.Equal(t, nil, c.Arg())
+		rpc, err := runMessageTest(t, ctype, v)
+		require.NoError(t, err)
+		c, ok := rpc.(*rpcCallCompressedMessage)
+		require.True(t, ok)
+		require.Equal(t, MethodCallCompressed, c.Type())
+		require.Equal(t, ctype, c.Compression())
+		require.Equal(t, SeqNumber(999), c.SeqNo())
+		require.Equal(t, "abc.hello", c.Name())
+		require.Equal(t, nil, c.Arg())
+	})
 }
 
 func TestMessageDecodeValidExtraParams(t *testing.T) {

--- a/rpc/protocol.go
+++ b/rpc/protocol.go
@@ -45,8 +45,9 @@ func (t MethodType) String() string {
 type CompressionType int
 
 const (
-	CompressionNone CompressionType = 0
-	CompressionGzip CompressionType = 1
+	CompressionNone       CompressionType = 0
+	CompressionGzip       CompressionType = 1
+	CompressionMsgpackzip CompressionType = 2
 )
 
 func (t CompressionType) String() string {
@@ -55,6 +56,8 @@ func (t CompressionType) String() string {
 		return "none"
 	case CompressionGzip:
 		return "gzip"
+	case CompressionMsgpackzip:
+		return "msgpackzip"
 	default:
 		return fmt.Sprintf("Compression(%d)", t)
 	}
@@ -64,6 +67,8 @@ func (t CompressionType) NewCompressor() compressor {
 	switch t {
 	case CompressionGzip:
 		return newGzipCompressor()
+	case CompressionMsgpackzip:
+		return newMsgpackzipCompressor()
 	default:
 		return nil
 	}


### PR DESCRIPTION
adds new compression type `CompressionMsgpackzip` using https://github.com/keybase/msgpackzip to compress messagepack keys only. useful for endpoints with sensitive values that should not be compressed