### PR TITLE
Add Dialable interface and option to specify a custom dialable for TLS connections

### DIFF
--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -376,6 +376,7 @@ func TestDialableTransport(t *testing.T) {
 	conn := NewConnectionWithTransport(unitTester, ct,
 		testErrorUnwrapper{}, output, opts)
 	require.Error(t, conn.connect(context.TODO()))
+	conn.Shutdown()
 
 	timer := time.NewTimer(2 * time.Second)
 	defer timer.Stop()
@@ -414,6 +415,7 @@ func TestDialableTLSConn(t *testing.T) {
 		&md)
 
 	require.Error(t, conn.connect(context.TODO()))
+	conn.Shutdown()
 
 	timer := time.NewTimer(1 * time.Second)
 	defer timer.Stop()

--- a/rpc/connection_test.go
+++ b/rpc/connection_test.go
@@ -3,6 +3,8 @@ package rpc
 import (
 	"errors"
 	"fmt"
+	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -328,4 +330,102 @@ func TestConnectionClientNotifyCancel(t *testing.T) {
 
 	err = <-errCh
 	require.Equal(t, err, ctx.Err())
+}
+
+type mockedDialable struct {
+	mutex            sync.Mutex
+	dialWasCalled    bool
+	setoptsWasCalled bool
+}
+
+func (md *mockedDialable) SetOpts(timeout time.Duration, keepAlive time.Duration) {
+	md.mutex.Lock()
+	md.setoptsWasCalled = true
+	md.mutex.Unlock()
+}
+
+func (md *mockedDialable) Dial(ctx context.Context, network string, addr string) (net.Conn, error) {
+	md.mutex.Lock()
+	md.dialWasCalled = true
+	md.mutex.Unlock()
+	return nil, fmt.Errorf("This is a mock")
+}
+
+func TestDialableTransport(t *testing.T) {
+	unitTester := &unitTester{
+		doneChan: make(chan bool),
+	}
+	output := testLogOutput{t}
+	opts := ConnectionOpts{
+		WrapErrorFunc: testWrapError,
+		TagsFunc:      testLogTags,
+	}
+
+	uriStr := "fmprpc://localhost:8080"
+	uri, err := ParseFMPURI(uriStr)
+	require.NoError(t, err)
+
+	wef := func(err error) interface{} {
+		require.NoError(t, err)
+		return err
+	}
+
+	md := mockedDialable{dialWasCalled: false, setoptsWasCalled: false}
+
+	ct := NewConnectionTransportWithDialable(uri, nil, wef, DefaultMaxFrameLength, &md)
+	conn := NewConnectionWithTransport(unitTester, ct,
+		testErrorUnwrapper{}, output, opts)
+	require.Error(t, conn.connect(context.TODO()))
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-unitTester.doneChan:
+		break
+	case <-timer.C:
+		break
+	}
+
+	// Set opts isn't called since no timeout or backoff was specified
+	md.mutex.Lock()
+	require.True(t, md.dialWasCalled)
+	md.mutex.Unlock()
+}
+
+func TestDialableTLSConn(t *testing.T) {
+	unitTester := &unitTester{
+		doneChan: make(chan bool),
+	}
+	output := testLogOutput{t}
+	opts := ConnectionOpts{
+		WrapErrorFunc: testWrapError,
+		TagsFunc:      testLogTags,
+	}
+
+	uriStr := "fmprpc+tls://localhost:8080"
+	uri, err := ParseFMPURI(uriStr)
+	require.NoError(t, err)
+
+	md := mockedDialable{dialWasCalled: false, setoptsWasCalled: false}
+	conn := NewTLSConnectionWithDialable(NewFixedRemote(uri.HostPort),
+		nil, testErrorUnwrapper{},
+		unitTester, nil,
+		output, DefaultMaxFrameLength, opts,
+		&md)
+
+	require.Error(t, conn.connect(context.TODO()))
+
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-unitTester.doneChan:
+		break
+	case <-timer.C:
+		break
+	}
+
+	md.mutex.Lock()
+	require.True(t, md.dialWasCalled)
+	require.True(t, md.setoptsWasCalled)
+	md.mutex.Unlock()
 }


### PR DESCRIPTION
This is necessary for PICNIC-94. The TCP connections to gregor are established inside of this library which does not expose a way to swap out the dialer. The alternative to changing this library is to copy the entire `ConnectionTransportTLS` implementation out of the library and into `keybase/client` which does not seem very clean. 

See https://github.com/keybase/client/pull/18023 for the corresponding WIP `keybase/client` changes. I've tested this code by integrating with the client and confirming that chat works through the proxy. 